### PR TITLE
Add fields to designate root CA for cheaper SSL CAs

### DIFF
--- a/bws.js
+++ b/bws.js
@@ -27,6 +27,12 @@ var serverOpts = {};
 if (config.https) {
   serverOpts.key = fs.readFileSync(config.privateKeyFile || './ssl/privatekey.pem');
   serverOpts.cert = fs.readFileSync(config.certificateFile || './ssl/certificate.pem');
+  // This sets the intermediate CA certs only if they have all been designated in the config.js
+  if (config.CAinter1 && config.CAinter2 && config.CAroot) {
+    serverOpts.ca = [fs.readFileSync(config.CAinter1),
+                     fs.readFileSync(config.CAinter2),
+                     fs.readFileSync(config.CAroot)
+                    ];};
 }
 
 var start = function(cb) {

--- a/config.js
+++ b/config.js
@@ -10,6 +10,12 @@ var config = {
   // https: true,
   // privateKeyFile: 'private.pem',
   // certificateFile: 'cert.pem',
+  ////// The following is only for certs which are not
+  ////// trusted by nodejs 'https' by default
+  ////// CAs like Verisign do not require this
+  // CAinter1: '', // ex. 'COMODORSADomainValidationSecureServerCA.crt'
+  // CAinter2: '', // ex. 'COMODORSAAddTrustCA.crt'
+  // CAroot: '', // ex. 'AddTrustExternalCARoot.crt'
 
   storageOpts: {
     mongoDb: {


### PR DESCRIPTION
#217 could possibly use this by adding default values with `||` and  having a script run during npm install that would generate rsa keys and self-sign certs etc.