### PR TITLE
Feat/allow delete after locktimeout

### DIFF
--- a/lib/model/txproposal.js
+++ b/lib/model/txproposal.js
@@ -132,6 +132,18 @@ TxProposal.prototype.getActors = function() {
 
 
 /**
+ * getApprovers
+ *
+ * @return {String[]} copayerIds that approved the tx proposal (accept)
+ */
+TxProposal.prototype.getApprovers = function() {
+  return _.pluck(
+    _.filter(this.actions, {
+      type: 'accept'
+    }), 'copayerId');
+};
+
+/**
  * getActionBy
  *
  * @param {String} copayerId

--- a/lib/server.js
+++ b/lib/server.js
@@ -889,7 +889,7 @@ WalletService.prototype.removePendingTx = function(opts, cb) {
 
       var deleteLockTime = self.getRemainingDeleteLockTime(txp);
       if (deleteLockTime > 0) {
-        return cb(new ClientError('TXCANNOTREMOVE', 'Cannot remove this tx proposal during locktime. Time remaining:' + deleteLockTime));
+        return cb(new ClientError('TXCANNOTREMOVE', 'Cannot remove this tx proposal during locktime'));
       }
       self.storage.removeTx(self.walletId, txp.id, function() {
         self._notify('TxProposalRemoved', {}, cb);

--- a/lib/server.js
+++ b/lib/server.js
@@ -843,6 +843,26 @@ WalletService.prototype.removeWallet = function(opts, cb) {
   });
 };
 
+WalletService.prototype.getRemainingDeleteLockTime = function(txp) {
+  var now = Math.floor(Date.now() / 1000);
+
+  var lockTimeRemaining = txp.createdOn + WalletService.deleteLockTime - now;
+  if (lockTimeRemaining < 0)
+    return 0;
+
+  // not the creator? need to wait
+  if (txp.creatorId !== this.copayerId)
+    return lockTimeRemaining;
+
+  // has other approvers? need to wait
+  var approvers = txp.getApprovers();
+  if (approvers.length > 1 || (approvers.length == 1 && approvers[0] !== this.copayerId))
+    return lockTimeRemaining;
+  
+  return 0;
+};
+
+
 /**
  * removePendingTx
  *
@@ -866,14 +886,10 @@ WalletService.prototype.removePendingTx = function(opts, cb) {
       if (!txp.isPending())
         return cb(new ClientError('TXNOTPENDING', 'Transaction proposal not pending'));
 
-      var now =  Math.floor(Date.now() / 1000);
-      if (now - txp.createdOn < WalletService.lockTimeoutHours * 3600) {
-        if (txp.creatorId !== self.copayerId)
-          return cb(new ClientError('Only creators can remove pending proposals  during locktime'));
 
-        var approvers = txp.getApprovers();
-        if (approvers.length > 1 || (approvers.length == 1 && approvers[0] !== self.copayerId))
-          return cb(new ClientError('TXACTIONED', 'Cannot remove a proposal signed/rejected by other copayers  during locktime'));
+      var deleteLockTime = self.getRemainingDeleteLockTime(txp);
+      if (deleteLockTime > 0) {
+        return cb(new ClientError('TXCANNOTREMOVE', 'Cannot remove this tx proposal during locktime. Time remaining:' + deleteLockTime));
       }
 
       self._notify('TxProposalRemoved', {}, function() {
@@ -1104,6 +1120,10 @@ WalletService.prototype.getPendingTxs = function(opts, cb) {
   self.storage.fetchPendingTxs(self.walletId, function(err, txps) {
     if (err) return cb(err);
 
+    _.each(txps,function(txp){
+      txp.deleteLockTime = self.getRemainingDeleteLockTime(txp);
+    });
+
     return cb(null, txps);
   });
 };
@@ -1320,7 +1340,8 @@ WalletService.prototype.getTxHistory = function(opts, cb) {
   });
 };
 
-WalletService.lockTimeoutHours = 24;
+// in seconds 
+WalletService.deleteLockTime = 24 * 3600;
 
 WalletService.scanConfig = {
   SCAN_WINDOW: 20,

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,7 @@ var blockchainExplorerOpts;
 var messageBroker;
 
 
+
 /**
  * Creates an instance of the Bitcore Wallet Service.
  * @constructor
@@ -865,14 +866,15 @@ WalletService.prototype.removePendingTx = function(opts, cb) {
       if (!txp.isPending())
         return cb(new ClientError('TXNOTPENDING', 'Transaction proposal not pending'));
 
+      var now =  Math.floor(Date.now() / 1000);
+      if (now - txp.createdOn < WalletService.lockTimeoutHours * 3600) {
+        var actors = txp.getActors();
+        if (txp.creatorId !== self.copayerId)
+          return cb(new ClientError('Only creators can remove pending proposals  during locktime'));
 
-      if (txp.creatorId !== self.copayerId)
-        return cb(new ClientError('Only creators can remove pending proposals'));
-
-      var actors = txp.getActors();
-
-      if (actors.length > 1 || (actors.length == 1 && actors[0] !== self.copayerId))
-        return cb(new ClientError('TXACTIONED', 'Cannot remove a proposal signed/rejected by other copayers'));
+        if (actors.length > 1 || (actors.length == 1 && actors[0] !== self.copayerId))
+          return cb(new ClientError('TXACTIONED', 'Cannot remove a proposal signed/rejected by other copayers  during locktime'));
+      }
 
       self._notify('TxProposalRemoved', {}, function() {
         self.storage.removeTx(self.walletId, txp.id, cb);
@@ -1318,6 +1320,7 @@ WalletService.prototype.getTxHistory = function(opts, cb) {
   });
 };
 
+WalletService.lockTimeoutHours = 24;
 
 WalletService.scanConfig = {
   SCAN_WINDOW: 20,

--- a/lib/server.js
+++ b/lib/server.js
@@ -858,7 +858,7 @@ WalletService.prototype.getRemainingDeleteLockTime = function(txp) {
   var approvers = txp.getApprovers();
   if (approvers.length > 1 || (approvers.length == 1 && approvers[0] !== this.copayerId))
     return lockTimeRemaining;
-  
+
   return 0;
 };
 
@@ -891,9 +891,8 @@ WalletService.prototype.removePendingTx = function(opts, cb) {
       if (deleteLockTime > 0) {
         return cb(new ClientError('TXCANNOTREMOVE', 'Cannot remove this tx proposal during locktime. Time remaining:' + deleteLockTime));
       }
-
-      self._notify('TxProposalRemoved', {}, function() {
-        self.storage.removeTx(self.walletId, txp.id, cb);
+      self.storage.removeTx(self.walletId, txp.id, function() {
+        self._notify('TxProposalRemoved', {}, cb);
       });
     });
   });
@@ -1120,7 +1119,7 @@ WalletService.prototype.getPendingTxs = function(opts, cb) {
   self.storage.fetchPendingTxs(self.walletId, function(err, txps) {
     if (err) return cb(err);
 
-    _.each(txps,function(txp){
+    _.each(txps, function(txp) {
       txp.deleteLockTime = self.getRemainingDeleteLockTime(txp);
     });
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -868,11 +868,11 @@ WalletService.prototype.removePendingTx = function(opts, cb) {
 
       var now =  Math.floor(Date.now() / 1000);
       if (now - txp.createdOn < WalletService.lockTimeoutHours * 3600) {
-        var actors = txp.getActors();
         if (txp.creatorId !== self.copayerId)
           return cb(new ClientError('Only creators can remove pending proposals  during locktime'));
 
-        if (actors.length > 1 || (actors.length == 1 && actors[0] !== self.copayerId))
+        var approvers = txp.getApprovers();
+        if (approvers.length > 1 || (approvers.length == 1 && approvers[0] !== self.copayerId))
           return cb(new ClientError('TXACTIONED', 'Cannot remove a proposal signed/rejected by other copayers  during locktime'));
       }
 

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -2656,6 +2656,7 @@ describe('Wallet service', function() {
         });
       });
     });
+      
 
     it('should allow creator to remove an unsigned TX', function(done) {
       server.removePendingTx({
@@ -2669,7 +2670,7 @@ describe('Wallet service', function() {
       });
     });
 
-    it('should allow creator to remove an signed TX by himself', function(done) {
+    it('should allow creator to remove a signed TX by himself', function(done) {
       var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey);
       server.signTx({
         txProposalId: txp.id,
@@ -2754,7 +2755,7 @@ describe('Wallet service', function() {
       });
     });
 
-    it('should not allow creator copayer to remove an TX signed by other copayer', function(done) {
+    it('should not allow creator copayer to remove a TX signed by other copayer, in less than 24hrs', function(done) {
       helpers.getAuthServer(wallet.copayers[1].id, function(server2) {
         var signatures = helpers.clientSign(txp, TestData.copayers[1].xPrivKey);
         server2.signTx({
@@ -2772,6 +2773,52 @@ describe('Wallet service', function() {
         });
       });
     });
+
+
+    it('should allow creator copayer to remove a TX signed by other copayer, after 24hrs', function(done) {
+      helpers.getAuthServer(wallet.copayers[1].id, function(server2) {
+        var signatures = helpers.clientSign(txp, TestData.copayers[1].xPrivKey);
+        server2.signTx({
+          txProposalId: txp.id,
+          signatures: signatures,
+        }, function(err) {
+          should.not.exist(err);
+
+          var clock = sinon.useFakeTimers(Date.now()+1+24*3600*1000);
+          server.removePendingTx({
+            txProposalId: txp.id
+          }, function(err) {
+            should.not.exist(err);
+            clock.restore();
+            done();
+          });
+        });
+      });
+    });
+
+
+    it('should allow other copayer to remove a TX signed, after 24hrs', function(done) {
+      helpers.getAuthServer(wallet.copayers[1].id, function(server2) {
+        var signatures = helpers.clientSign(txp, TestData.copayers[1].xPrivKey);
+        server2.signTx({
+          txProposalId: txp.id,
+          signatures: signatures,
+        }, function(err) {
+          should.not.exist(err);
+
+          var clock = sinon.useFakeTimers(Date.now()+1+24*3600*1000);
+          server2.removePendingTx({
+            txProposalId: txp.id
+          }, function(err) {
+            should.not.exist(err);
+            clock.restore();
+            done();
+          });
+        });
+      });
+    });
+
+
   });
 
   describe('#getTxHistory', function() {

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -2774,6 +2774,25 @@ describe('Wallet service', function() {
       });
     });
 
+    it('should allow creator copayer to remove a TX rejected by other copayer, in less than 24hrs', function(done) {
+      helpers.getAuthServer(wallet.copayers[1].id, function(server2) {
+        var signatures = helpers.clientSign(txp, TestData.copayers[1].xPrivKey);
+        server2.rejectTx({
+          txProposalId: txp.id,
+          signatures: signatures,
+        }, function(err) {
+          should.not.exist(err);
+          server.removePendingTx({
+            txProposalId: txp.id
+          }, function(err) {
+            should.not.exist(err);
+            done();
+          });
+        });
+      });
+    });
+
+
 
     it('should allow creator copayer to remove a TX signed by other copayer, after 24hrs', function(done) {
       helpers.getAuthServer(wallet.copayers[1].id, function(server2) {


### PR DESCRIPTION
- allow any copayer to delete a tx proposal after 24hr
- allow the creator of a tx proposal to delete as long as it does not have signatures from other copayer (it could have rejections)
- adds '.deleteLockTime' to getPendingTxs response. =0 if the tx can be delete by the querying copayer, >0, if it can't be deleted.