### PR TITLE
Allow to exclude certain UTXO from coin selection

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -917,7 +917,7 @@ WalletService.prototype.getFeeLevels = function(opts, cb) {
   });
 };
 
-WalletService.prototype._selectTxInputs = function(txp, cb) {
+WalletService.prototype._selectTxInputs = function(txp, utxosToExclude, cb) {
   var self = this;
 
   function sortUtxos(utxos) {
@@ -940,6 +940,12 @@ WalletService.prototype._selectTxInputs = function(txp, cb) {
 
   self.getUtxos({}, function(err, utxos) {
     if (err) return cb(err);
+
+    var excludeIndex = _.reduce(utxosToExclude, function(res, val) { res[val] = val; return res; }, {});
+
+    utxos = _.reject(utxos, function(utxo) {
+      return excludeIndex[utxo.txid + ":" + utxo.vout];
+    });
 
     var totalAmount;
     var availableAmount;
@@ -1167,7 +1173,7 @@ WalletService.prototype.createTx = function(opts, cb) {
           txp.version = '1.0.1';
         }
 
-        self._selectTxInputs(txp, function(err) {
+        self._selectTxInputs(txp, opts.utxosToExclude, function(err) {
           if (err) return cb(err);
 
           $.checkState(txp.inputs);

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -2429,6 +2429,18 @@ describe('Wallet service', function() {
         });
       });
     });
+    it('should not use UTXO provided in utxosToExclude option', function(done) {
+      helpers.stubUtxos(server, wallet, [1, 2, 3], function(utxos) {
+        var txOpts = helpers.createSimpleProposalOpts('18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7', 4.5, 'some message', TestData.copayers[0].privKey_1H_0);
+        txOpts.utxosToExclude = [ utxos[1].txid + ':' + utxos[1].vout ];
+        server.createTx(txOpts, function(err, tx) {
+          should.exist(err);
+          err.code.should.equal('INSUFFICIENT_FUNDS');
+          err.message.should.equal('Insufficient funds');
+          done();
+        });
+      });
+    });
   });
 
   describe('#createTx backoff time', function(done) {


### PR DESCRIPTION
Optional array of UTXOs (in ``txid:vout`` form) can be passed to BWS in ``utxosToExclude`` proposal option. When selecting inputs for proposal, these UTXOs will not be used.

Usage example: exclude colored UTXOs when doing coin selection with BWS