### PR TITLE
errors from external services have different code and message props

### DIFF
--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -80,8 +80,8 @@ ExpressApp.prototype.start = function(opts, cb) {
     } else {
       var code, message;
       if (_.isObject(err)) {
-        code = err.code;
-        message = err.message;
+        code = err.code || err.statusCode;
+        message = err.message || err.body;
       }
       var m = message || err.toString();
 


### PR DESCRIPTION
CloudFlare errors don't have 'code' or 'message' properties. They look like this:

{"statusCode":503,"body":"Server not yet ready. Sync Percentage:NaN","headers":{"server":"cloudflare-nginx","date":"Tue, 25 Aug 2015 23:47:53 GMT","content-type":"text/html; charset=utf-8","transfer-encoding":"chunked","connection":"keep-alive","set-cookie":["__cfduid=d5472f39e00a3984118c6eb0ddfbb4ab21440546473; expires=Wed, 24-Aug-16 23:47:53 GMT; path=/; domain=.bitpay.com; HttpOnly"],"x-powered-by":"Express","access-control-allow-origin":"*","access-control-allow-methods":"GET, POST, OPTIONS, PUT, DELETE","access-control-allow-headers":"X-Requested-With,Content-Type,Authorization","access-control-expose-headers":"X-Email-Needs-Validation,X-Quota-Per-Item,X-Quota-Items-Limit,X-RateLimit-Limit,X-RateLimit-Remaining","vary":"Accept-Encoding","cf-ray":"21bb2f39e781283a-SJC"},"request":{"uri":{"protocol":"https:","slashes":true,"auth":null,"host":"test-insight.bitpay.com:443","port":"443","hostname":"test-insight.bitpay.com","hash":null,"search":null,"query":null,"pathname":"/api/addrs/utxo","path":"/api/addrs/utxo","href":"https://test-insight.bitpay.com:443/api/addrs/utxo"},"method":"POST","headers":{"accept":"application/json","content-type":"application/json","content-length":26759}}}

Without this PR, the error appears in the log as '[object Object]'. An alternative with be to change 'err.toString()' to 'JSON.stringify(err)' in line 86.