### PR TITLE
Limit nb of consecutive addresses without activity

### DIFF
--- a/lib/blockchainexplorers/insight.js
+++ b/lib/blockchainexplorers/insight.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var _ = require('lodash');
+var async = require('async');
 var $ = require('preconditions').singleton();
 var log = require('npmlog');
 log.debug = log.verbose;
@@ -114,8 +115,10 @@ Insight.prototype.getTransactions = function(addresses, from, to, cb) {
 };
 
 Insight.prototype.getAddressActivity = function(addresses, cb) {
-  function getOneAddressActivity(address, cb) {
-    var url = this.url + this.apiPrefix + '/addr/' + address;
+  var self = this;
+
+  function getOneAddressActivity(address, cb2) {
+    var url = self.url + self.apiPrefix + '/addr/' + address;
     var args = {
       method: 'GET',
       url: url,
@@ -123,21 +126,26 @@ Insight.prototype.getAddressActivity = function(addresses, cb) {
     };
 
     request(args, function(err, res, result) {
-      if (res && res.statusCode == 404) return cb();
+      if (res && res.statusCode == 404) return cb2();
       if (err || res.statusCode !== 200)
-        return cb(_parseErr(err, res));
+        return cb2(_parseErr(err, res));
 
       var nbTxs = result.unconfirmedTxApperances + result.txApperances;
-      return cb(null, nbTxs > 0);
+      return cb2(null, nbTxs > 0);
     });
   };
 
   addresses = [].concat(addresses);
+
+  if (addresses.length == 1) {
+    return getOneAddressActivity(addresses[0], cb);
+  }
+
   var activityFound = false;
   var i = 0;
 
   async.until(function() {
-    return activityFound;
+    return i == addresses.length || activityFound;
   }, function(next) {
     getOneAddressActivity(addresses[i++], function(err, res) {
       if (err) return next(err);

--- a/lib/blockchainexplorers/insight.js
+++ b/lib/blockchainexplorers/insight.js
@@ -113,21 +113,39 @@ Insight.prototype.getTransactions = function(addresses, from, to, cb) {
   });
 };
 
-Insight.prototype.getAddressActivity = function(address, cb) {
-  var url = this.url + this.apiPrefix + '/addr/' + address;
-  var args = {
-    method: 'GET',
-    url: url,
-    json: true,
+Insight.prototype.getAddressActivity = function(addresses, cb) {
+  function getOneAddressActivity(address, cb) {
+    var url = this.url + this.apiPrefix + '/addr/' + address;
+    var args = {
+      method: 'GET',
+      url: url,
+      json: true,
+    };
+
+    request(args, function(err, res, result) {
+      if (res && res.statusCode == 404) return cb();
+      if (err || res.statusCode !== 200)
+        return cb(_parseErr(err, res));
+
+      var nbTxs = result.unconfirmedTxApperances + result.txApperances;
+      return cb(null, nbTxs > 0);
+    });
   };
 
-  request(args, function(err, res, result) {
-    if (res && res.statusCode == 404) return cb();
-    if (err || res.statusCode !== 200)
-      return cb(_parseErr(err, res));
+  addresses = [].concat(addresses);
+  var activityFound = false;
+  var i = 0;
 
-    var nbTxs = result.unconfirmedTxApperances + result.txApperances;
-    return cb(null, nbTxs > 0);
+  async.until(function() {
+    return activityFound;
+  }, function(next) {
+    getOneAddressActivity(addresses[i++], function(err, res) {
+      if (err) return next(err);
+      activityFound = !!res;
+      return next();
+    });
+  }, function(err) {
+    return cb(err, activityFound);
   });
 };
 

--- a/lib/blockchainexplorers/insight.js
+++ b/lib/blockchainexplorers/insight.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var _ = require('lodash');
-var async = require('async');
 var $ = require('preconditions').singleton();
 var log = require('npmlog');
 log.debug = log.verbose;
@@ -114,46 +113,23 @@ Insight.prototype.getTransactions = function(addresses, from, to, cb) {
   });
 };
 
-Insight.prototype.getAddressActivity = function(addresses, cb) {
+Insight.prototype.getAddressActivity = function(address, cb) {
   var self = this;
 
-  function getOneAddressActivity(address, cb2) {
-    var url = self.url + self.apiPrefix + '/addr/' + address;
-    var args = {
-      method: 'GET',
-      url: url,
-      json: true,
-    };
-
-    request(args, function(err, res, result) {
-      if (res && res.statusCode == 404) return cb2();
-      if (err || res.statusCode !== 200)
-        return cb2(_parseErr(err, res));
-
-      var nbTxs = result.unconfirmedTxApperances + result.txApperances;
-      return cb2(null, nbTxs > 0);
-    });
+  var url = self.url + self.apiPrefix + '/addr/' + address;
+  var args = {
+    method: 'GET',
+    url: url,
+    json: true,
   };
 
-  addresses = [].concat(addresses);
+  request(args, function(err, res, result) {
+    if (res && res.statusCode == 404) return cb();
+    if (err || res.statusCode !== 200)
+      return cb(_parseErr(err, res));
 
-  if (addresses.length == 1) {
-    return getOneAddressActivity(addresses[0], cb);
-  }
-
-  var activityFound = false;
-  var i = 0;
-
-  async.until(function() {
-    return i == addresses.length || activityFound;
-  }, function(next) {
-    getOneAddressActivity(addresses[i++], function(err, res) {
-      if (err) return next(err);
-      activityFound = !!res;
-      return next();
-    });
-  }, function(err) {
-    return cb(err, activityFound);
+    var nbTxs = result.unconfirmedTxApperances + result.txApperances;
+    return cb(null, nbTxs > 0);
   });
 };
 

--- a/lib/errors/errordefinitions.js
+++ b/lib/errors/errordefinitions.js
@@ -17,6 +17,7 @@ var errors = {
   INVALID_ADDRESS: 'Invalid address',
   KEY_IN_COPAYER: 'Key already registered',
   LOCKED_FUNDS: 'Funds are locked by pending transaction proposals',
+  MAIN_ADDRESS_GAP_REACHED: 'Maximum number of consecutive addresses without activity reached',
   NOT_AUTHORIZED: 'Not authorized',
   TOO_MANY_KEYS: 'Too many keys registered',
   TX_ALREADY_BROADCASTED: 'The transaction proposal is already broadcasted',

--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -259,8 +259,19 @@ ExpressApp.prototype.start = function(opts, cb) {
     });
   });
 
-
+  // DEPRECATED
   router.post('/v1/addresses/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      server.createAddress({
+        ignoreMaxGap: true
+      }, function(err, address) {
+        if (err) return returnError(err, res, req);
+        res.json(address);
+      });
+    });
+  });
+
+  router.post('/v2/addresses/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       server.createAddress(req.body, function(err, address) {
         if (err) return returnError(err, res, req);

--- a/lib/model/address.js
+++ b/lib/model/address.js
@@ -19,6 +19,7 @@ Address.create = function(opts) {
   x.publicKeys = opts.publicKeys;
   x.network = Bitcore.Address(x.address).toObject().network;
   x.type = opts.type || WalletUtils.SCRIPT_TYPES.P2SH;
+  x.hasActivity = undefined;
   return x;
 };
 
@@ -34,6 +35,7 @@ Address.fromObj = function(obj) {
   x.path = obj.path;
   x.publicKeys = obj.publicKeys;
   x.type = obj.type || WalletUtils.SCRIPT_TYPES.P2SH;
+  x.hasActivity = obj.hasActivity;
   return x;
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -692,29 +692,52 @@ WalletService.prototype.getPreferences = function(opts, cb) {
   });
 };
 
+WalletService.prototype._canCreateAddress = function(ignoreMaxGap, cb) {
+  var self = this;
+
+  if (ignoreMaxGap) return cb(null, true);
+  self.storage.fetchAddresses(self.walletId, function(err, addresses) {
+    if (err) return cb(err);
+    var latestAddresses = _.takeRight(_.reject(addresses, {
+      isChange: true
+    }), WalletService.MAX_MAIN_ADDRESS_GAP);
+    if (latestAddresses.length < WalletService.MAX_MAIN_ADDRESS_GAP) return cb(null, true);
+
+    var bc = self._getBlockchainExplorer(latestAddresses[0].network);
+    bc.getAddressActivity(latestAddresses, cb);
+  });
+};
 
 /**
  * Creates a new address.
  * @param {Object} opts
+ * @param {Boolean} [opts.ignoreMaxGap=false] - Ignore constraint of maximum number of consecutive addresses without activity
  * @returns {Address} address
  */
 WalletService.prototype.createAddress = function(opts, cb) {
   var self = this;
+
+  opts = opts || {};
 
   self._runLocked(cb, function(cb) {
     self.getWallet({}, function(err, wallet) {
       if (err) return cb(err);
       if (!wallet.isComplete()) return cb(Errors.WALLET_NOT_COMPLETE);
 
-      var address = wallet.createAddress(false);
-
-      self.storage.storeAddressAndWallet(wallet, address, function(err) {
+      self._canCreateAddress(opts.ignoreMaxGap, function(err, canCreate) {
         if (err) return cb(err);
+        if (!canCreate) return cb(Errors.MAIN_ADDRESS_GAP_REACHED);
 
-        self._notify('NewAddress', {
-          address: address.address,
-        }, function() {
-          return cb(null, address);
+        var address = wallet.createAddress(false);
+
+        self.storage.storeAddressAndWallet(wallet, address, function(err) {
+          if (err) return cb(err);
+
+          self._notify('NewAddress', {
+            address: address.address,
+          }, function() {
+            return cb(null, address);
+          });
         });
       });
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -696,6 +696,7 @@ WalletService.prototype._canCreateAddress = function(ignoreMaxGap, cb) {
   var self = this;
 
   if (ignoreMaxGap) return cb(null, true);
+
   self.storage.fetchAddresses(self.walletId, function(err, addresses) {
     if (err) return cb(err);
     var latestAddresses = _.takeRight(_.reject(addresses, {
@@ -704,7 +705,7 @@ WalletService.prototype._canCreateAddress = function(ignoreMaxGap, cb) {
     if (latestAddresses.length < WalletService.MAX_MAIN_ADDRESS_GAP) return cb(null, true);
 
     var bc = self._getBlockchainExplorer(latestAddresses[0].network);
-    bc.getAddressActivity(latestAddresses, cb);
+    bc.getAddressActivity(_.pluck(latestAddresses, 'address'), cb);
   });
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -702,10 +702,31 @@ WalletService.prototype._canCreateAddress = function(ignoreMaxGap, cb) {
     var latestAddresses = _.takeRight(_.reject(addresses, {
       isChange: true
     }), WalletService.MAX_MAIN_ADDRESS_GAP);
-    if (latestAddresses.length < WalletService.MAX_MAIN_ADDRESS_GAP) return cb(null, true);
+    if (latestAddresses.length < WalletService.MAX_MAIN_ADDRESS_GAP || _.any(latestAddresses, {
+      hasActivity: true
+    })) return cb(null, true);
 
     var bc = self._getBlockchainExplorer(latestAddresses[0].network);
-    bc.getAddressActivity(_.pluck(latestAddresses, 'address'), cb);
+    var activityFound = false;
+    var i = latestAddresses.length;
+    async.whilst(function() {
+      return i > 0 && !activityFound;
+    }, function(next) {
+      bc.getAddressActivity(latestAddresses[--i].address, function(err, res) {
+        if (err) return next(err);
+        activityFound = !!res;
+        return next();
+      });
+    }, function(err) {
+      if (err) return cb(err);
+      if (!activityFound) return cb(null, false);
+
+      var address = latestAddresses[i];
+      address.hasActivity = true;
+      self.storage.storeAddress(self.walletId, address, function(err) {
+        return cb(err, true);
+      });
+    });
   });
 };
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,7 +34,6 @@ var blockchainExplorerOpts;
 var messageBroker;
 var serviceVersion;
 
-var MAX_KEYS = 100;
 
 /**
  * Creates an instance of the Bitcore Wallet Service.
@@ -52,6 +51,8 @@ function WalletService() {
   this.notifyTicker = 0;
 };
 
+
+WalletService.MAX_KEYS = 100;
 
 // Time after which a Tx proposal can be erased by any copayer. in seconds
 WalletService.DELETE_LOCKTIME = 24 * 3600;
@@ -518,7 +519,7 @@ WalletService.prototype.addAccess = function(opts, cb) {
         return cb(Errors.NOT_AUTHORIZED);
       }
 
-      if (copayer.requestPubKeys.length > MAX_KEYS)
+      if (copayer.requestPubKeys.length > WalletService.MAX_KEYS)
         return cb(Errors.TOO_MANY_KEYS);
 
       self._addKeyToCopayer(wallet, copayer, opts, cb);

--- a/lib/server.js
+++ b/lib/server.js
@@ -723,7 +723,7 @@ WalletService.prototype._canCreateAddress = function(ignoreMaxGap, cb) {
 
       var address = latestAddresses[i];
       address.hasActivity = true;
-      self.storage.storeAddress(self.walletId, address, function(err) {
+      self.storage.storeAddress(address, function(err) {
         return cb(err, true);
       });
     });

--- a/lib/server.js
+++ b/lib/server.js
@@ -63,9 +63,11 @@ WalletService.BACKOFF_OFFSET = 3;
 // Time a copayer need to wait to create a new TX after her tx previous proposal we rejected. (incremental). in Minutes.
 WalletService.BACKOFF_TIME = 2;
 
+WalletService.MAX_MAIN_ADDRESS_GAP = 20;
+
 // Fund scanning parameters
 WalletService.SCAN_CONFIG = {
-  maxGap: 20,
+  maxGap: WalletService.MAX_MAIN_ADDRESS_GAP,
 };
 
 WalletService.FEE_LEVELS = [{

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -383,6 +383,17 @@ Storage.prototype.fetchAddresses = function(walletId, cb) {
   });
 };
 
+Storage.prototype.storeAddress = function(walletId, address, cb) {
+  var self = this;
+
+  self.db.collection(collections.ADDRESSES).update({
+    address: address.address
+  }, address, {
+    w: 1,
+    upsert: false,
+  }, cb);
+};
+
 Storage.prototype.storeAddressAndWallet = function(wallet, addresses, cb) {
   var self = this;
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -383,7 +383,7 @@ Storage.prototype.fetchAddresses = function(walletId, cb) {
   });
 };
 
-Storage.prototype.storeAddress = function(walletId, address, cb) {
+Storage.prototype.storeAddress = function(address, cb) {
   var self = this;
 
   self.db.collection(collections.ADDRESSES).update({

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -1667,6 +1667,32 @@ describe('Wallet service', function() {
           });
         });
       });
+
+      it.only('should fail to create more consecutive addresses with no activity than allowed', function(done) {
+        var MAX_MAIN_ADDRESS_GAP_old = WalletService.MAX_MAIN_ADDRESS_GAP;
+        var n = WalletService.MAX_MAIN_ADDRESS_GAP = 2;
+        helpers.stubAddressActivity([]);
+        async.map(_.range(n), function(i, next) {
+          server.createAddress({}, next);
+        }, function(err, addresses) {
+          addresses.length.should.equal(n);
+
+          server.createAddress({}, function(err, address) {
+            should.exist(err);
+            should.not.exist(address);
+            err.code.should.equal('MAIN_ADDRESS_GAP_REACHED');
+            server.createAddress({
+              ignoreMaxGap: true
+            }, function(err, address) {
+              should.not.exist(err);
+              should.exist(address);
+              address.path.should.equal('m/0/' + n);
+              WalletService.MAX_MAIN_ADDRESS_GAP = MAX_MAIN_ADDRESS_GAP_old;
+              done();
+            });
+          });
+        });
+      });
     });
 
     describe('1-of-1 (BIP44 & P2PKH)', function() {

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -1668,7 +1668,7 @@ describe('Wallet service', function() {
         });
       });
 
-      it.only('should fail to create more consecutive addresses with no activity than allowed', function(done) {
+      it('should fail to create more consecutive addresses with no activity than allowed', function(done) {
         var MAX_MAIN_ADDRESS_GAP_old = WalletService.MAX_MAIN_ADDRESS_GAP;
         var n = WalletService.MAX_MAIN_ADDRESS_GAP = 2;
         helpers.stubAddressActivity([]);

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -1751,6 +1751,29 @@ describe('Wallet service', function() {
           });
         });
       });
+
+      it('should cache address activity', function(done) {
+        var MAX_MAIN_ADDRESS_GAP_old = WalletService.MAX_MAIN_ADDRESS_GAP;
+        WalletService.MAX_MAIN_ADDRESS_GAP = 2;
+        helpers.stubAddressActivity([]);
+        async.map(_.range(2), function(i, next) {
+          server.createAddress({}, next);
+        }, function(err, addresses) {
+          addresses.length.should.equal(2);
+
+          helpers.stubAddressActivity([addresses[1].address]);
+          var getAddressActivitySpy = sinon.spy(blockchainExplorer, 'getAddressActivity');
+          server.createAddress({}, function(err, address) {
+            should.not.exist(err);
+            server.createAddress({}, function(err, address) {
+              should.not.exist(err);
+              getAddressActivitySpy.callCount.should.equal(1);
+              WalletService.MAX_MAIN_ADDRESS_GAP = MAX_MAIN_ADDRESS_GAP_old;
+              done();
+            });
+          });
+        });
+      });
     });
   });
 

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -237,8 +237,8 @@ helpers.stubFeeLevels = function(levels) {
 };
 
 helpers.stubAddressActivity = function(activeAddresses) {
-  blockchainExplorer.getAddressActivity = function(addresses, cb) {
-    return cb(null, _.intersection(activeAddresses, [].concat(addresses)).length > 0);
+  blockchainExplorer.getAddressActivity = function(address, cb) {
+    return cb(null, _.contains(activeAddresses, address));
   };
 };
 


### PR DESCRIPTION
Note from manual testing: after reaching the last authorized address, if an address scan process is started, the wallet will end up not showing an address on the receive tab. (It tries to generate a new one but the server will deny). Could this affect deployed clients?

Note 2: performance of generating a new address has suffered with this change. Especially on relatively long streams of unused addresses.