### PR TITLE
Bug/firstimets

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1701,11 +1701,15 @@ WalletService.prototype._normalizeTxHistory = function(txs) {
       }
     });
 
+    var t = tx.time; // blocktime
+    if (!t || _.isNaN(t)) t = tx.firstSeenTs;
+    if (!t || _.isNaN(t)) t = now;
+
     return {
       txid: tx.txid,
       confirmations: tx.confirmations,
       fees: parseInt((tx.fees * 1e8).toFixed(0)),
-      time: tx.firstSeenTs || (!_.isNaN(tx.time) ? tx.time : now) || now,
+      time: t,
       inputs: inputs,
       outputs: outputs,
     };

--- a/lib/server.js
+++ b/lib/server.js
@@ -1701,7 +1701,7 @@ WalletService.prototype._normalizeTxHistory = function(txs) {
       }
     });
 
-    var t = tx.time; // blocktime
+    var t = tx.blocktime; // blocktime
     if (!t || _.isNaN(t)) t = tx.firstSeenTs;
     if (!t || _.isNaN(t)) t = now;
 

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -4495,7 +4495,12 @@ describe('Wallet service', function() {
       server.getTxHistory({}, function(err, txs) {
         should.not.exist(err);
         should.exist(txs);
-        txs.length.should.equal(2);
+        txs.length.should.equal(TestData.history.length);
+        var i = 0;
+        _.each(txs, function(tx) {
+          var h = TestData.history[i++];
+          tx.time.should.equal(h.confirmations ? h.blocktime : h.firstSeenTs);
+        });
         done();
       });
     });
@@ -4769,12 +4774,13 @@ describe('Wallet service', function() {
         txid: 'xx'
       })
       helpers.stubHistory(h);
+      var l = TestData.history.length;
 
       server.getTxHistory({}, function(err, txs) {
         should.not.exist(err);
         should.exist(txs);
-        txs.length.should.equal(3);
-        txs[2].action.should.equal('invalid');
+        txs.length.should.equal(l + 1);
+        txs[l].action.should.equal('invalid');
         done();
       });
     });

--- a/test/testdata.js
+++ b/test/testdata.js
@@ -135,7 +135,48 @@ var copayers = [{
   pubKey_1H_0: '0266cdb57b8a4d7c1b5b20ddeea43705420c6e3aef2c2979a3768b7b585839a0d3'
 }, ];
 
-var history = [{
+var history = [
+  {
+  txid: "0279ef7b21630f859deb723e28beac9e7011660bd1346c2da40321d2f7e34f04",
+  vin: [{
+    txid: "c8e221141e8bb60977896561b77fa59d6dacfcc10db82bf6f5f923048b11c70d",
+    vout: 0,
+    n: 0,
+    addr: "2N6Zutg26LEC4iYVxi7SHhopVLP1iZPU1rZ",
+    valueSat: 485645,
+    value: 0.00485645,
+  }, {
+    txid: "6e599eea3e2898b91087eb87e041c5d8dec5362447a8efba185ed593f6dc64c0",
+    vout: 1,
+    n: 1,
+    addr: "2MyqmcWjmVxW8i39wdk1CVPdEqKyFSY9H1S",
+    valueSat: 885590,
+    value: 0.0088559,
+  }],
+  vout: [{
+    value: "0.00045753",
+    n: 0,
+    scriptPubKey: {
+      addresses: [
+        "2NAVFnsHqy5JvqDJydbHPx393LFqFFBQ89V"
+      ]
+    },
+  }, {
+    value: "0.01300000",
+    n: 1,
+    scriptPubKey: {
+      addresses: [
+        "mq4D3Va5mYHohMEHrgHNGzCjKhBKvuEhPE"
+      ]
+    }
+  }],
+  confirmations: 0,
+  firstSeenTs: 1424471000,
+  valueOut: 0.01345753,
+  valueIn: 0.01371235,
+  fees: 0.00025482
+},
+  {
   txid: "0279ef7b21630f859deb723e28beac9e7011660bd1346c2da40321d2f7e34f04",
   vin: [{
     txid: "c8e221141e8bb60977896561b77fa59d6dacfcc10db82bf6f5f923048b11c70d",
@@ -171,7 +212,7 @@ var history = [{
   }],
   confirmations: 2,
   firstSeenTs: 1424471041,
-  blocktime: 1424471041,
+  blocktime: 1424471051,
   valueOut: 0.01345753,
   valueIn: 0.01371235,
   fees: 0.00025482


### PR DESCRIPTION
uses `blocktime` instead of `firstSeenTs` in TxHistory, when available.

Needed when ,multiple instances of insight are running.