### PR TITLE
Mirror changes in bitcore-wallet-client

### DIFF
--- a/lib/model/txproposal.js
+++ b/lib/model/txproposal.js
@@ -169,7 +169,7 @@ TxProposal.prototype._buildTx = function() {
     t.to(self.toAddress, self.amount);
   } else if (self.outputs) {
     _.each(self.outputs, function(o) {
-      $.checkState(!o.script != !o.toAddress, 'Output should have either toAddress or script specified');
+      $.checkState(o.script || o.toAddress, 'Output should have either toAddress or script specified');
       if (o.script) {
         t.addOutput(new Bitcore.Transaction.Output({
           script: o.script,
@@ -192,9 +192,13 @@ TxProposal.prototype._buildTx = function() {
 
   // Shuffle outputs for improved privacy
   if (t.outputs.length > 1) {
-    $.checkState(t.outputs.length == self.outputOrder.length);
+    var outputOrder = self.outputOrder;
+    if (!t.getChangeOutput()) {
+      outputOrder = _.dropRight(outputOrder);
+    }
+    $.checkState(t.outputs.length == outputOrder.length);
     t.sortOutputs(function(outputs) {
-      return _.map(self.outputOrder, function(i) {
+      return _.map(outputOrder, function(i) {
         return outputs[i];
       });
     });


### PR DESCRIPTION
I was surprised to see this code duplication. What was the reason for dismissing bitcore-wallet-utils? Also I cannot find former-BWU unit tests anymore.

Anyway, this PR reflects the following client-side changes:
https://github.com/bitpay/bitcore-wallet-client/pull/187
https://github.com/bitpay/bitcore-wallet-client/pull/188