### PR TITLE
Dockerized, added license, added kerberos.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+*.md
+!Dockerfile.md
+!installation.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM node
+
+MAINTAINER Rick Moran <moran@crowbits.com>
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    mongodb-clients \
+  && rm -rf /var/lib/apt/lists/*
+
+COPY . /bws
+
+WORKDIR /bws
+
+# I have no idea why I have to do this twice. 
+# Perhaps some node loving individual can explain it to me.
+RUN npm install;npm install
+
+RUN sed 's/localhost:27017/bwsdb:27017/g' config.js > config.js.new; \
+    mv config.js.new config.js
+
+EXPOSE 3232 3231 3380 443
+
+CMD npm start && tail -f logs/bws.log

--- a/Dockerfile.md
+++ b/Dockerfile.md
@@ -1,0 +1,39 @@
+# Run BWS under docker
+
+## Build the docker
+
+To build the container, you do something like:
+
+docker build -t [YOUR DOCKER USER]/bitcore-wallet-service:[THE CONTAINER VERSION] .
+
+A concrete example of which is:
+
+docker build -t drhayt/bitcore-wallet-service:latest .
+
+## Run the container
+
+Going over all the methods to run and manage docker containers is far beyond the scope of this document.
+
+What is important is that you understand what the docker container provides when it is run, and what the expectations of the built docker container.  The expectations are:
+
+1.  MongoDB
+ 1. The Container expects there to be a mongodb intance somewhere.
+ 1. The name of the expected mongodb instance is ___bwsdb___
+ 1. The mongodb port is expected to be 27017.
+ 1. The mongodb connection is unauthenticated.
+
+The container provides:
+
+1.  NO PUBLIC ACCESS
+ 1.  Unless you map ports on the docker run commandline, no ports will be exposed.
+
+## Run Examples
+### Dockerized MongoDB on the same Docker host
+
+docker run --name bwsdb  -v /mongodb/data/db:/data/db -d mongo:latest
+
+docker run --name bws -p 3232:3232 --link bwsdb:bwsdb -d bitcore-wallet-service
+
+### An external mongodb
+
+docker run --name bws -p 3232:3232 --add-host bwsdb:1.2.3.4  -d bitcore-wallet-service

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "wallet",
     "bitcore"
   ],
+  "license" : "MIT",
   "repository": {
     "url": "git@github.com:bitpay/bitcore-wallet-service.git",
     "type": "git"
@@ -26,6 +27,7 @@
     "express": "^4.10.0",
     "inherits": "^2.0.1",
     "json-stable-stringify": "^1.0.0",
+    "kerberos": "~0.0.17",
     "locker": "^0.1.0",
     "locker-server": "^0.1.3",
     "lodash": "^3.10.1",


### PR DESCRIPTION
I quite enjoy running the wallet service under docker.  I think others might want to as well.
Included in this pull request are:
1.  A Dockerfile to facilitate building the docker container
2.  A .dockerignore file that ensures we do not copy too much into the container.
3.  Some markdown to help bootstrap the container experience.
4.  A patch to the package.json to help it stop complaining about the lack of a license.
5.  A patch to the package.json to include kerberos as recommended in recent mongodb documentation