### PR TITLE
fix: do not remove scripts from outputs

### DIFF
--- a/lib/model/txproposal.js
+++ b/lib/model/txproposal.js
@@ -34,7 +34,7 @@ TxProposal.create = function(opts) {
   x.payProUrl = opts.payProUrl;
   x.changeAddress = opts.changeAddress;
   x.outputs = _.map(opts.outputs, function(output) {
-    return _.pick(output, ['amount', 'toAddress', 'message']);
+    return _.pick(output, ['amount', 'toAddress', 'message', 'script']);
   });
   x.outputOrder = _.shuffle(_.range(x.outputs.length + 1));
   x.walletM = opts.walletM;


### PR DESCRIPTION
So that txs with outputs with scripts are not rejected. [Outputs can either have toAddress or script](https://github.com/bitpay/bitcore-wallet-service/blob/4c9b685e1c9b2319dc1ce42f132768c2f869ba86/lib/model/txproposal.js#L151)