### PR TITLE
fix: wrong output value calculation in _buildTx

### DIFF
--- a/lib/model/txproposal.js
+++ b/lib/model/txproposal.js
@@ -162,7 +162,7 @@ TxProposal.prototype._buildTx = function() {
   t.fee(self.fee);
 
   var totalInputs = _.sum(self.inputs, 'satoshis');
-  var totalOutputs = _.sum(self.outputs, 'satoshis');
+  var totalOutputs = _.sum(self.outputs, 'amount');
 
   if (totalInputs - totalOutputs - self.fee > 0 && self.changeAddress) {
     t.change(self.changeAddress.address);
@@ -182,7 +182,7 @@ TxProposal.prototype._buildTx = function() {
   }
 
   // Validate actual inputs vs outputs independently of Bitcore
-  var totalInputs = _.sum(t.inputs, 'satoshis');
+  var totalInputs = _.sum(t.inputs, 'output.satoshis');
   var totalOutputs = _.sum(t.outputs, 'satoshis');
 
   $.checkState(totalInputs - totalOutputs <= Defaults.MAX_TX_FEE);


### PR DESCRIPTION
Fixed two things:
1. in TxProposal object outputs never have ``satoshis`` property ([proof](https://github.com/bitpay/bitcore-wallet-client/blob/fb9559a66d8df4f0c3871fc9791827d3f1aadcb3/lib/api.js#L1540)) thus ``_.sum(self.outputs, 'satoshis')`` is always 0. 
2. In bitcore Transaction inputs have no ``satoshis`` property thus ``_.sum(t.inputs, 'satoshis')`` is always 0.