### PR TITLE
Support broadcastByThirdParty option for .broadcastTx

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -2253,6 +2253,12 @@ WalletService.prototype.broadcastTx = function(opts, cb) {
     }, function(err, txp) {
       if (err) return cb(err);
 
+      if (opts.broadcastByThirdParty) {
+        return self._processBroadcast(txp, {
+          byThirdParty: true
+        }, cb);
+      }
+
       if (txp.status == 'broadcasted') return cb(Errors.TX_ALREADY_BROADCASTED);
       if (txp.status != 'accepted') return cb(Errors.TX_NOT_ACCEPTED);
 


### PR DESCRIPTION
New option ``broadcastByThirdParty`` for ``broadcastTx`` was introduced. If set, this option tells BWS that given tx was already broadcasted by other service.
