### PR TITLE
Optionally disable outputs shuffling for createTx

### DIFF
--- a/lib/model/txproposal.js
+++ b/lib/model/txproposal.js
@@ -36,7 +36,10 @@ TxProposal.create = function(opts) {
   x.outputs = _.map(opts.outputs, function(output) {
     return _.pick(output, ['amount', 'toAddress', 'message', 'script']);
   });
-  x.outputOrder = _.shuffle(_.range(x.outputs.length + 1));
+  x.outputOrder = _.range(x.outputs.length + 1);
+  if (!opts.noShuffleOutputs) {
+    x.outputOrder = _.shuffle(x.outputOrder);
+  }
   x.walletM = opts.walletM;
   x.walletN = opts.walletN;
   x.requiredSignatures = x.walletM;

--- a/lib/server.js
+++ b/lib/server.js
@@ -1878,6 +1878,7 @@ WalletService.prototype._validateAndSanitizeTxOpts = function(wallet, opts, cb) 
  * @param {string} opts.dryRun[=false] - Optional. Simulate the action but do not change server state.
  * @param {Array} opts.inputs - Optional. Inputs for this TX
  * @param {number} opts.fee - Optional. Use an fixed fee for this TX (only when opts.inputs is specified)
+ * @param {Boolean} opts.noShuffleOutputs - Optional. If set, TX outputs won't be shuffled. Defaults to false
  * @returns {TxProposal} Transaction proposal.
  */
 WalletService.prototype.createTx = function(opts, cb) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -1926,6 +1926,7 @@ WalletService.prototype.createTx = function(opts, cb) {
           customData: opts.customData,
           inputs: opts.inputs,
           fee: opts.inputs && !_.isNumber(opts.feePerKb) ? opts.fee : null,
+          noShuffleOutputs: opts.noShuffleOutputs
         };
 
         txp = Model.TxProposal.create(txOpts);


### PR DESCRIPTION
Introducing ``noShuffleOutputs`` option for ``createTx``. If set, it disables outputs shuffling for newly created tx. Useful for colored transactions where outputs order matters