### PR TITLE
Update default History_Limit to 50

### DIFF
--- a/lib/common/defaults.js
+++ b/lib/common/defaults.js
@@ -54,7 +54,7 @@ Defaults.FIAT_RATE_PROVIDER = 'BitPay';
 Defaults.FIAT_RATE_FETCH_INTERVAL = 10; // In minutes
 Defaults.FIAT_RATE_MAX_LOOK_BACK_TIME = 120; // In minutes
 
-Defaults.HISTORY_LIMIT = 100;
+Defaults.HISTORY_LIMIT = 50;
 
 // The maximum amount of an UTXO to be considered too big to be used in the tx before exploring smaller
 // alternatives (proportinal to tx amount).


### PR DESCRIPTION
The default 100 is causing error when loading the wallet transactions history.

[error] Error: Error querying the blockchain
[Error: Error querying the blockchain]

This is BWS log showing the error:

WARN REQUEST FAIL: https://insight.bitpay.com:443/api/addrs/txs?from=0&to=100 STATUS CODE: 503
WARN Insight https://insight.bitpay.com:443/api/addrs/txs?from=0&to=100 Returned Status: 503
ERR! /v1/txhistory/?r=69638 :500:Error querying the blockchain