### PR TITLE
skip log for notification requests

### DIFF
--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -65,9 +65,14 @@ ExpressApp.prototype.start = function(opts, cb) {
       return req.copayerId
     });
 
-
-
-    this.app.use(morgan(' :remote-addr :date[iso] ":method :url" :status :res[content-length] :response-time ":user-agent" :walletId :copayerId'));
+    var logFormat = ':remote-addr :date[iso] ":method :url" :status :res[content-length] :response-time ":user-agent" :walletId :copayerId';
+    var logOpts = {
+      skip: function(req, res) {
+        if (res.statusCode != 200) return false;
+        return req.path.indexOf('/notifications/') >= 0;
+      }
+    };
+    this.app.use(morgan(logFormat, logOpts));
   }
 
 


### PR DESCRIPTION
Adguard Assistant?rand=636077196474413350:70 Synchronous XMLHttpRequest on the main thread is deprecated because of its detrimental effects to the end user's experience. For more help, check https://xhr.spec.whatwg.org/.