### PR TITLE
do not check input/output balance if tx has inputs of unknown value

### DIFF
--- a/lib/model/txproposal.js
+++ b/lib/model/txproposal.js
@@ -187,8 +187,11 @@ TxProposal.prototype._buildTx = function() {
   var totalInputs = _.sum(t.inputs, 'output.satoshis');
   var totalOutputs = _.sum(t.outputs, 'satoshis');
 
-  $.checkState(totalInputs > 0 && totalOutputs > 0 && totalInputs >= totalOutputs);
-  $.checkState(totalInputs - totalOutputs <= Defaults.MAX_TX_FEE);
+  // cannot validate input/output balance reliably if some inputs have unknown value
+  if (!_.some(t.inputs, function(i) { return i.output.satoshis === 0; })) {
+    $.checkState(totalInputs > 0 && totalOutputs > 0 && totalInputs >= totalOutputs);
+    $.checkState(totalInputs - totalOutputs <= Defaults.MAX_TX_FEE);
+  }
 
   return t;
 };

--- a/lib/server.js
+++ b/lib/server.js
@@ -1382,10 +1382,14 @@ WalletService.prototype._estimateFee = function(txp) {
 WalletService.prototype._checkTx = function(txp) {
   var bitcoreError;
 
+  // cannot validate input/output balance reliably if some inputs have unknown value
+  var hasUnknownInputValue = _.some(txp.inputs, {'satoshis': 0});
+
   var serializationOpts = {
     disableIsFullySigned: true,
     disableSmallFees: true,
     disableLargeFees: true,
+    disableMoreOutputThanInput: hasUnknownInputValue,
   };
 
   if (txp.getEstimatedSize() / 1000 > Defaults.MAX_TX_SIZE_IN_KB)

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -2446,6 +2446,30 @@ describe('Wallet service', function() {
             });
           });
         });
+        it('should not check outputs amount is bigger then inputs if having unknown input value', function(done) {
+          helpers.stubUtxos(server, wallet, [1], function(utxos) {
+            server.getUtxos({}, function(err, utxos) {
+              should.not.exist(err);
+              utxos[0].satoshis = 0; // setting "unknown" input amount
+              var inputs = [utxos[0]];
+              var txOpts = {
+                outputs: [{
+                  toAddress: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
+                  amount: 2.5e8,
+                }],
+                feePerKb: 100e2,
+                inputs: inputs,
+              };
+              server.createTx(txOpts, function(err, tx) {
+                should.not.exist(err);
+                should.exist(tx);
+                var txids = _.pluck(tx.inputs, 'txid');
+                txids.should.contain(utxos[0].txid);
+                done();
+              });
+            });
+          });
+        });
       });
 
       describe('Foreign ID', function() {


### PR DESCRIPTION
If transaction is not created with BWS, some of the inputs may have unknown value. In this case we cannot reliably check that tx is not spending more then specified by inputs, so these checks (both by Bitcore and BWS) will be disabled for such transactions.
