### PR TITLE
Use bitcore-lib as a peerDependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ before_install:
   - export CXX="g++-4.8" CC="gcc-4.8"
 install:
   # Install peerDependencies on > npm3
-  # When all dependencies declare bitcore-lib as a peerDependency this can be bumped up, but this matches the current ecosystem version expected by dependencies
-  - if [ $(npm --version | sed 's/\..*//g') -ge 3 ]; then npm install bitcore-lib@0.13.7; fi
+  - if [ $(npm --version | sed 's/\..*//g') -ge 3 ]; then npm install bitcore-lib; fi
   - npm install
 after_success:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ node_js:
 before_install:
   - export CXX="g++-4.8" CC="gcc-4.8"
 install:
+  # When all dependencies declare bitcore-lib as a peerDependency this can be bumped up, but this matches the current version expected by dependencies
+  - npm install bitcore-lib@0.13.7
   - npm install
 after_success:
   - npm run coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ node_js:
 before_install:
   - export CXX="g++-4.8" CC="gcc-4.8"
 install:
-  # When all dependencies declare bitcore-lib as a peerDependency this can be bumped up, but this matches the current version expected by dependencies
-  - npm install bitcore-lib@0.13.7
+  # Install peerDependencies on > npm3
+  # When all dependencies declare bitcore-lib as a peerDependency this can be bumped up, but this matches the current ecosystem version expected by dependencies
+  - if [ $(npm --version | sed 's/\..*//g') -ge 3 ]; then npm install bitcore-lib@0.13.7; fi
   - npm install
 after_success:
   - npm run coveralls

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tingodb": "^0.3.4"
   },
   "peerDependencies": {
-    "bitcore-lib": "~0.13.7"
+    "bitcore-lib": "~0.14.0"
   },
   "scripts": {
     "start": "./start.sh",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
   },
   "dependencies": {
     "async": "^0.9.2",
-    "bitcore-lib": "^0.14.0",
     "body-parser": "^1.11.0",
     "compression": "^1.6.2",
     "coveralls": "^2.11.2",
@@ -61,6 +60,9 @@
     "sinon": "1.10.3",
     "supertest": "*",
     "tingodb": "^0.3.4"
+  },
+  "peerDependencies": {
+    "bitcore-lib": "^0.14.0"
   },
   "scripts": {
     "start": "./start.sh",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "tingodb": "^0.3.4"
   },
   "peerDependencies": {
-    "bitcore-lib": "^0.14.0"
+    "bitcore-lib": "~0.13.7"
   },
   "scripts": {
     "start": "./start.sh",


### PR DESCRIPTION
One wrinkle to using the bitcore stack is the obvious need to have a singleton `bitcore-lib`.  The `bitcoin-lib` package hosts the `bitcoind` library and there are good reasons to not wanting to have multiple `bitcoind` instances running on the same machine.

However, I am not a fan of the runtime check and would rather have all packages be declaring `bitcoin-lib` in `peerDependencies`.  This way the enclosing package can specify whatever version of `bitcoin-lib` it wants and `npm` will inform user if there is an unmet dependency at _install_ time rather than _run_ time.

I have a working example of `bitcore-lib` running as a peerDependency at  [bitcore-docker-build](https://github.com/CaptEmulation/bitcore-docker-build) which is also running testnet at [bitcore.soapbubble.online/insight](https://bitcore.soapbubble.online/insight)
: 