### PR TITLE
Replace ServerWithAuth by Server in getFiatRate

### DIFF
--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -660,16 +660,20 @@ ExpressApp.prototype.start = function(opts, cb) {
   });
 
   router.get('/v1/fiatrates/:code/', function(req, res) {
-    getServerWithAuth(req, res, function(server) {
-      var opts = {
-        code: req.params['code'],
-        source: req.query.source,
-        ts: +req.query.ts,
-      };
-      server.getFiatRate(opts, function(err, rates) {
-        if (err) return returnError(err, res, req);
-        res.json(rates);
-      });
+    var server;
+    var opts = {
+      code: req.params['code'],
+      provider: req.query.provider,
+      ts: +req.query.ts,
+    };
+    try {
+      server = getServer(req, res);
+    } catch (ex) {
+      return returnError(ex, res, req);
+    }
+    server.getFiatRate(opts, function(err, rates) {
+      if (err) return returnError(err, res, req);
+      res.json(rates);
     });
   });
 


### PR DESCRIPTION
To get a fiat rate there is no need to pass by the authentication mechanisms.

Also, previously the BWS was waiting for a 'source' in query, but the BWC it is sending a 'provider' query, not 'source', turns out that it is impossible to the client to query a specific provider, because fiatRateService do not recognize the variable 'source'.

Related PR: https://github.com/bitpay/bitcore-wallet-client/pull/365
Close: https://github.com/bitpay/bitcore-wallet-client/issues/364