### PR TITLE
Fix address generation

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -481,7 +481,9 @@ Storage.prototype.storeAddressAndWallet = function(wallet, addresses, cb) {
       return next(false);
     });
   }, function(newAddresses) {
-    if (newAddresses.length == 0) return cb();
+    if (newAddresses.length < addresses.length) {
+      log.warn('Attempted to store already existing addresses on wallet ' + wallet.id);
+    }
     self.db.collection(collections.ADDRESSES).insert(newAddresses, {
       w: 1
     }, function(err) {


### PR DESCRIPTION
On rare occasions, the address index gets out of sync with the latest generated address. Fix this by always storing the index.