### PR TITLE
Fixing inconsistent apiPrefix in blockchain explorer insight

### DIFF
--- a/lib/blockchainexplorers/insight.js
+++ b/lib/blockchainexplorers/insight.js
@@ -12,7 +12,7 @@ function Insight(opts) {
   $.checkArgument(_.contains(['livenet', 'testnet'], opts.network));
   $.checkArgument(opts.url);
 
-  this.apiPrefix = opts.apiPrefix || '/api';
+  this.apiPrefix = opts.apiPrefix || '/insight-api';
   this.network = opts.network || 'livenet';
   this.hosts = opts.url;
   this.userAgent = opts.userAgent || 'bws';


### PR DESCRIPTION
The default (or fallback) apiPrefix for an insight-based blockchain explorer is currently set to ```/api```, yet, the default of a bitcore node running insight-api is using ```/insight-api```. This pull requests harmonizes the default setups, and avoids issues when setting up an instance.

See also ```bitcorenode/index.js```