### PR TITLE
Added an index for copayerId in sessions

### DIFF
--- a/lib/storage.js
+++ b/lib/storage.js
@@ -83,6 +83,9 @@ Storage.prototype._createIndexes = function() {
     copayerId: 1,
     txid: 1,
   });
+  this.db.collection(collections.SESSIONS).createIndex({
+    copayerId: 1
+  });
 };
 
 Storage.prototype.connect = function(opts, cb) {


### PR DESCRIPTION
When your BWS database gets to around 4Gb in space and around 50,000 wallets, your MongoDB server won't be able to keep up without an index on copayerId in sessions, causing every single request to BWS to fail.

This fixed the problem for us:

db.sessions.createIndex({ copayerId: 1 });