### PR TITLE
Still use previously defined blockchainExplorerOpts even if explicit …

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1079,8 +1079,12 @@ WalletService.prototype._getBlockchainExplorer = function(coin, network) {
   var opts = {};
 
   if (this.blockchainExplorer) return this.blockchainExplorer;
-  if (this.blockchainExplorerOpts && this.blockchainExplorerOpts[coin] && this.blockchainExplorerOpts[coin][network]) {
-    opts = this.blockchainExplorerOpts[coin][network];
+  if (this.blockchainExplorerOpts) {
+    if (this.blockchainExplorerOpts[coin] && this.blockchainExplorerOpts[coin][network]) {
+      opts = this.blockchainExplorerOpts[coin][network];
+    } else if (this.blockchainExplorerOpts[network]) {
+      opts = this.blockchainExplorerOpts[network];
+    }
   }
   // TODO: provider should be configurable
   opts.provider = 'insight';
@@ -1285,7 +1289,7 @@ WalletService.prototype._getBalanceFromAddresses = function(opts, cb, i) {
       return cb(null, balance);
 
     self.storage.storeBalanceCache(self.walletId, opts.addresses, balance, function(err) {
-      if (err) 
+      if (err)
         self.logw('Could not save cache:',err);
 
       return cb(null, balance);
@@ -1371,7 +1375,7 @@ WalletService.prototype._getActiveAddresses = function(cb) {
       self.logw('Could not fetch active addresses from cache', err);
       return cb();
     }
-    if (!_.isArray(addressesWB)) 
+    if (!_.isArray(addressesWB))
       addressesWB = [];
 
     var now = Math.floor(Date.now() / 1000);
@@ -1397,7 +1401,7 @@ WalletService.prototype._checkAndUpdateAddressCount = function(twoStepCache, cb)
   self.storage.countAddresses(self.walletId, function(err, addressCount) {
     if (err) return cb(err);
 
-    if (addressCount < Defaults.TWO_STEP_BALANCE_THRESHOLD) 
+    if (addressCount < Defaults.TWO_STEP_BALANCE_THRESHOLD)
       return cb(null, false);
 
     twoStepCache.addressCount = addressCount;
@@ -1673,14 +1677,14 @@ WalletService.prototype.getFeeLevels = function(opts, cb) {
   if (!Utils.checkValueInCollection(opts.network, Constants.NETWORKS))
     return cb(new ClientError('Invalid network'));
 
-  
+
   function checkAndUseFeeLevelsCache (next) {
     self.storage.checkAndUseFeeLevelsCache(opts, next);
   };
 
   function storeFeeLevelsCache(values,next) {
     self.storage.storeFeeLevelsCache(opts, values, next);
-  }; 
+  };
 
   checkAndUseFeeLevelsCache(function(err, values) {
     if (err) return cb(err);


### PR DESCRIPTION
…cointype isn't specified. This allows for apiPrefix to be appropriately passed through the entire stack when running a local instance of a bitcore node.

Fixed issue as outlined in https://github.com/bitpay/bitcore-wallet-service/issues/750.