### PR TITLE
sendgrid transport fix

### DIFF
--- a/config.js
+++ b/config.js
@@ -100,9 +100,11 @@ var config = {
   // },
   // To use sendgrid:
   // var sgTransport = require('nodemail-sendgrid-transport');
-  // mailer:sgTransport({
-  //  api_user: xxx,
-  //  api_key: xxx,
+  // mailer: sgTransport({
+  //   auth: {
+  //     api_user: xxx (Not required if using api key from sendgrid),
+  //     api_key: xxx,
+  //   }
   // });
 };
 module.exports = config;

--- a/lib/emailservice.js
+++ b/lib/emailservice.js
@@ -111,7 +111,7 @@ EmailService.prototype.start = function(opts, cb) {
       done();
     },
     function(done) {
-      self.mailer = opts.mailer || nodemailer.createTransport(opts.emailOpts);
+      self.mailer = nodemailer.createTransport(opts.mailer || opts.emailOpts);
       done();
     },
   ], function(err) {


### PR DESCRIPTION
Sending mail via Sendgrid fails as sgTransport is initialized wrongly & self.mailer is not initialized as a function in lib/emailservice.js when using sendgrid mailer