### PR TITLE
Chore/cashaddr

### DIFF
--- a/config.js
+++ b/config.js
@@ -65,7 +65,7 @@ var config = {
       },
       testnet: {
         provider: 'v8',
-        url: 'http://localhost:3000',
+       url: 'http://localhost:3000',
         //url: 'https://api.bitcore.io',
       },
 

--- a/lib/blockchainexplorers/v8/client.js
+++ b/lib/blockchainexplorers/v8/client.js
@@ -106,7 +106,7 @@ Client.prototype.importAddresses = async function(params) {
   const { payload, pubKey } = params;
   const url = `${this.baseUrl}/wallet/${pubKey}`;
 
-  console.log('add addresses:',url); //TODO
+  console.log('addAddresses:',url, payload); //TODO
   const signature = this.sign({ method: 'POST', url, payload});
   let h = { 'x-signature': signature};
   return request.post(url, {

--- a/lib/errors/errordefinitions.js
+++ b/lib/errors/errordefinitions.js
@@ -12,6 +12,7 @@ var errors = {
   COPAYER_VOTED: 'Copayer already voted on this transaction proposal',
   DUST_AMOUNT: 'Amount below dust threshold',
   INCORRECT_ADDRESS_NETWORK: 'Incorrect address network',
+  ONLY_CASHADDR: 'Only cashaddr wo prefix is allowed for outputs',
   INSUFFICIENT_FUNDS: 'Insufficient funds',
   INSUFFICIENT_FUNDS_FOR_FEE: 'Insufficient funds for fee',
   INVALID_ADDRESS: 'Invalid address',

--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -346,6 +346,8 @@ ExpressApp.prototype.start = function(opts, cb) {
     });
   });
 
+
+  
   router.get('/v1/txproposals/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       server.getPendingTxs({}, function(err, pendings) {
@@ -396,7 +398,21 @@ ExpressApp.prototype.start = function(opts, cb) {
     });
   });
 
+  // DEPRECATED (no cashaddr by default)
   router.post('/v3/addresses/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      var opts = req.body;
+      opts = opts || {};
+      opts.noCashAddr = true;
+      server.createAddress(opts, function(err, address) {
+        if (err) return returnError(err, res, req);
+        res.json(address);
+      });
+    });
+  });
+
+
+  router.post('/v4/addresses/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       server.createAddress(req.body, function(err, address) {
         if (err) return returnError(err, res, req);
@@ -404,6 +420,7 @@ ExpressApp.prototype.start = function(opts, cb) {
       });
     });
   });
+
 
   router.get('/v1/addresses/', function(req, res) {
     getServerWithAuth(req, res, function(server) {

--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -348,7 +348,17 @@ ExpressApp.prototype.start = function(opts, cb) {
 
 
   
+  // DEPRECATED (do not use cashaddr)
   router.get('/v1/txproposals/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      server.getPendingTxs({noCashAddr: true}, function(err, pendings) {
+        if (err) return returnError(err, res, req);
+        res.json(pendings);
+      });
+    });
+  });
+
+  router.get('/v2/txproposals/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       server.getPendingTxs({}, function(err, pendings) {
         if (err) return returnError(err, res, req);
@@ -363,14 +373,29 @@ ExpressApp.prototype.start = function(opts, cb) {
     return returnError(err, res, req);
   });
 
+
+  // DEPRECATED, no cash addr
   router.post('/v2/txproposals/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
+      req.body.noCashAddr = true;
       server.createTx(req.body, function(err, txp) {
         if (err) return returnError(err, res, req);
         res.json(txp);
       });
     });
   });
+
+  router.post('/v3/txproposals/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      req.body.onlyCashAddr = true;
+      server.createTx(req.body, function(err, txp) {
+        if (err) return returnError(err, res, req);
+        res.json(txp);
+      });
+    });
+  });
+
+
 
   // DEPRECATED
   router.post('/v1/addresses/', function(req, res) {
@@ -546,7 +571,20 @@ ExpressApp.prototype.start = function(opts, cb) {
     });
   });
 
+  //
   router.post('/v1/txproposals/:id/publish/', function(req, res) {
+    getServerWithAuth(req, res, function(server) {
+      req.body.txProposalId = req.params['id'];
+      req.body.noCashAddr = true;
+      server.publishTx(req.body, function(err, txp) {
+        if (err) return returnError(err, res, req);
+        res.json(txp);
+        res.end();
+      });
+    });
+  });
+
+  router.post('/v2/txproposals/:id/publish/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
       req.body.txProposalId = req.params['id'];
       server.publishTx(req.body, function(err, txp) {
@@ -556,6 +594,8 @@ ExpressApp.prototype.start = function(opts, cb) {
       });
     });
   });
+
+
 
   // TODO Check HTTP verb and URL name
   router.post('/v1/txproposals/:id/broadcast/', function(req, res) {

--- a/lib/expressapp.js
+++ b/lib/expressapp.js
@@ -387,7 +387,6 @@ ExpressApp.prototype.start = function(opts, cb) {
 
   router.post('/v3/txproposals/', function(req, res) {
     getServerWithAuth(req, res, function(server) {
-      req.body.onlyCashAddr = true;
       server.createTx(req.body, function(err, txp) {
         if (err) return returnError(err, res, req);
         res.json(txp);

--- a/lib/model/address.js
+++ b/lib/model/address.js
@@ -54,7 +54,7 @@ Address.fromObj = function(obj) {
   return x;
 };
 
-Address._deriveAddress = function(scriptType, publicKeyRing, path, m, coin, network) {
+Address._deriveAddress = function(scriptType, publicKeyRing, path, m, coin, network, noNativeCashAddr) {
   $.checkArgument(Utils.checkValueInCollection(scriptType, Constants.SCRIPT_TYPES));
 
   var publicKeys = _.map(publicKeyRing, function(item) {
@@ -73,16 +73,25 @@ Address._deriveAddress = function(scriptType, publicKeyRing, path, m, coin, netw
       break;
   }
 
+
+
+  let addrStr = bitcoreAddress.toString(true); 
+  if (noNativeCashAddr && coin == 'bch') {
+    addrStr =  bitcoreAddress.toLegacyAddress();
+  }
+
   return {
     // bws still use legacy addresses for BCH
-    address: coin == 'bch' ? bitcoreAddress.toLegacyAddress() : bitcoreAddress.toString(),
+    address: addrStr,
     path: path,
     publicKeys: _.invokeMap(publicKeys, 'toString'),
   };
 };
 
-Address.derive = function(walletId, scriptType, publicKeyRing, path, m, coin, network, isChange) {
-  var raw = Address._deriveAddress(scriptType, publicKeyRing, path, m, coin, network);
+
+// noNativeCashAddr only for testing
+Address.derive = function(walletId, scriptType, publicKeyRing, path, m, coin, network, isChange, noNativeCashAddr) {
+  var raw = Address._deriveAddress(scriptType, publicKeyRing, path, m, coin, network, noNativeCashAddr);
   return Address.create(_.extend(raw, {
     coin: coin,
     walletId: walletId,

--- a/lib/model/wallet.js
+++ b/lib/model/wallet.js
@@ -60,6 +60,9 @@ Wallet.create = function(opts) {
   x.beAuthPrivateKey2 = null; 
   x.beAuthPublicKey2 = null; 
 
+  // x.nativeCashAddr opts is only for testing
+  x.nativeCashAddr = _.isUndefined(opts.nativeCashAddr) ? (x.coin == 'bch' ? true : null) : opts.nativeCashAddr;
+
   return x;
 };
 
@@ -94,6 +97,8 @@ Wallet.fromObj = function(obj) {
   x.beRegistered = obj.beRegistered;
   x.beAuthPrivateKey2 = obj.beAuthPrivateKey2; 
   x.beAuthPublicKey2 = obj.beAuthPublicKey2; 
+
+  x.nativeCashAddr = obj.nativeCashAddr;
 
   return x;
 };
@@ -184,12 +189,11 @@ Wallet.prototype.isScanning = function() {
 
 Wallet.prototype.createAddress = function(isChange, step) {
   $.checkState(this.isComplete());
-
   var self = this;
 
   var path = this.addressManager.getNewAddressPath(isChange, step);
   log.verbose('Deriving addr:' + path);
-  var address = Address.derive(self.id, this.addressType, this.publicKeyRing, path, this.m, this.coin, this.network, isChange);
+  var address = Address.derive(self.id, this.addressType, this.publicKeyRing, path, this.m, this.coin, this.network, isChange, !self.nativeCashAddr);
   return address;
 };
 

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -500,6 +500,7 @@ Storage.prototype.migrateToCashAddr = function(walletId, cb) {
 
   cursor.on("end", function() {
     console.log(`Migration to cash address of ${walletId} Finished`);
+    self.clearWalletCache(walletId,cb);
     return cb();
   }); 
 
@@ -876,6 +877,17 @@ Storage.prototype.softResetTxHistoryCache = function(walletId, cb) {
     upsert: true,
   }, cb);
 };
+
+
+Storage.prototype.clearWalletCache = function(walletId, cb) {
+  var self = this;
+  self.db.collection(collections.CACHE).remove({
+    walletId: walletId,
+  }, {
+    multi: 1
+  }, cb);
+};
+
 
 Storage.prototype.clearTxHistoryCache = function(walletId, cb) {
   var self = this;

--- a/lib/storage.js
+++ b/lib/storage.js
@@ -500,8 +500,7 @@ Storage.prototype.migrateToCashAddr = function(walletId, cb) {
 
   cursor.on("end", function() {
     console.log(`Migration to cash address of ${walletId} Finished`);
-    self.clearWalletCache(walletId,cb);
-    return cb();
+    return self.clearWalletCache(walletId,cb);
   }); 
 
   cursor.on("err", function(err) {

--- a/test/integration/cashAddrMigration.js
+++ b/test/integration/cashAddrMigration.js
@@ -1,0 +1,138 @@
+'use strict';
+
+var _ = require('lodash');
+var async = require('async');
+
+var chai = require('chai');
+var sinon = require('sinon');
+var should = chai.should();
+var log = require('npmlog');
+log.debug = log.verbose;
+log.level = 'info';
+
+var Bitcore = require('bitcore-lib');
+var Bitcore_ = {
+  btc: Bitcore,
+  bch: require('bitcore-lib-cash')
+};
+
+
+
+var Common = require('../../lib/common');
+var Utils = Common.Utils;
+var Constants = Common.Constants;
+var Defaults = Common.Defaults;
+
+var Model = require('../../lib/model');
+
+var WalletService = require('../../lib/server');
+
+var TestData = require('../testdata');
+var helpers = require('./helpers');
+var storage, blockchainExplorer, request;
+
+
+describe('Cash address migration', function() {
+  before(function(done) {
+    helpers.before(done);
+  });
+  beforeEach(function(done) {
+    helpers.beforeEach(function(res) {
+      storage = res.storage;
+      blockchainExplorer = res.blockchainExplorer;
+      helpers.setupGroupingBE(blockchainExplorer);
+      request = res.request;
+      done();
+    });
+  });
+  after(function(done) {
+    helpers.after(done);
+  });
+
+  describe('Migrate wallets', function() {
+
+    it('new BCH wallets should be  native cashAddr', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch', earlyRet: true}, function(s, w) {
+        let spy = sinon.spy(s.storage, 'migrateToCashAddr');
+        s.getWallet({}, function(err, w) {
+          let calls = spy.getCalls();
+          calls.should.be.empty();
+          helpers.stubUtxos(s, w, 1, function() {
+            s.getStatus({}, function(err, a) {
+              should.not.exist(err);
+              spy.restore();
+              done();
+            });
+          });
+        });
+      });
+    });
+
+
+    it('should create cashAddr addresses for new wallets', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch'}, function(s, w) {
+        helpers.createAddresses(s, w, 1, 1, function(main, change) {
+          helpers.stubUtxos(s, w, 1, function() {
+            s.getMainAddresses({}, function(err, a) {
+              should.not.exist(err);
+              a[0].address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
+              done();
+            });
+          });
+        });
+      });
+    });
+
+
+    it('should migrate old wallets', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch', earlyRet: true, nativeCashAddr: false}, function(s, w) {
+        let spy = sinon.spy(s.storage, 'migrateToCashAddr');
+
+        s.getWallet({}, function(err, w) {
+          let calls = spy.getCalls();
+          calls.length.should.equal(1);
+          spy.restore();
+          done();
+        });
+      });
+    });
+
+
+    it('should create cashAddr in migrated wallets', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch', nativeCashAddr: false}, function(s, w) {
+        helpers.createAddresses(s, w, 2, 2, function(main, change) {
+          s.getMainAddresses({}, function(err, a) {
+            should.not.exist(err);
+            a[0].address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
+            done();
+          });
+        });
+      });
+    });
+
+
+    it('should migrate old addresses', function(done) {
+      helpers.createAndJoinWallet(1, 1, {coin:'bch', earlyRet: true, nativeCashAddr: false}, function(s, w) {
+      s.createAddress({doNotMigrate: true}, function(err, address) {
+        address.address.should.equal('CbWsiNjh18ynQYc5jfYhhespEGrAaW8YUq');
+        s.createAddress({doNotMigrate: true}, function(err, address) {
+          address.address.should.equal('CbkZvkoMiBzxYDTzCvPUK9Mnbhv5FyQQCZ');
+          s.createAddress({doNotMigrate: true}, function(err, address) {
+            address.address.should.equal('CY6RRcu5Zwn25467jtXzGpmyxtJrDWmVG4');
+            s.getWallet({}, function(err, w) {
+              s.getMainAddresses({}, function(err, a) {
+                a[0].address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
+                a[1].address.should.equal('qrfere3rxlk3jjs7g28n952g8rjasjqcpgx3axq70t');
+                a[2].address.should.equal('qz4h98slcsjhgxdkt3yd8dxz02x8s0u4l5hs80s0q8');
+                should.not.exist(err);
+                done();
+              });
+            });
+          });
+        });
+      });
+      });
+    });
+  });
+});
+

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -530,10 +530,12 @@ helpers.createAddresses = function(server, wallet, main, change, cb) {
 
 helpers.createAndPublishTx = function(server, txOpts, signingKey, cb) {
   server.createTx(txOpts, function(err, txp) {
+    if (err) console.log(err);
     should.not.exist(err, "Error creating a TX");
     should.exist(txp,"Error... no txp");
     var publishOpts = helpers.getProposalSignatureOpts(txp, signingKey);
     server.publishTx(publishOpts, function(err) {
+      if (err) console.log(err);
       should.not.exist(err);
       return cb(txp);
     });

--- a/test/integration/helpers.js
+++ b/test/integration/helpers.js
@@ -195,6 +195,7 @@ helpers.createAndJoinWallet = function(m, n, opts, cb) {
     singleAddress: !!opts.singleAddress,
     coin: opts.coin || 'btc',
     network: opts.network || 'livenet',
+    nativeCashAddr: opts.nativeCashAddr,
   };
   if (_.isBoolean(opts.supportBIP44AndP2PKH))
     walletOpts.supportBIP44AndP2PKH = opts.supportBIP44AndP2PKH;
@@ -231,6 +232,7 @@ helpers.createAndJoinWallet = function(m, n, opts, cb) {
     }, function(err) {
       if (err) return new Error('Could not generate wallet');
       helpers.getAuthServer(copayerIds[0], function(s) {
+        if (opts.earlyRet) return cb(s);
         s.getWallet({}, function(err, w) {
           cb(s, w);
         });

--- a/test/integration/historyV8.js
+++ b/test/integration/historyV8.js
@@ -16,8 +16,6 @@ var Bitcore_ = {
   bch: require('bitcore-lib-cash')
 };
 
-
-
 var Common = require('../../lib/common');
 var Utils = Common.Utils;
 var Constants = Common.Constants;

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -2514,27 +2514,36 @@ console.log('[server.js.425:err:]',err); //TODO
     });
   });
 
-  var addrMap = {
-    btc: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
-    bch: 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X',
-  }
+  let testSet = [
+    {
+      coin: 'btc',
+      key: 'id44btc',
+      addr: '18PzpUFkFZE8zKWUPvfykkTxmB9oMR8qP7',
+      flags: {},
+    }, 
+    {
+      coin: 'bch',
+      key: 'id44bch',
+      addr: 'qpgjyj728rhu4gca2dqfzlpl8acnhzequshhgvev53',
+      flags: {},
+    }, 
+    {
+      coin: 'bch',
+      key: 'id44bch',
+      addr: 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X',
+      flags: { noCashAddr: true },
+    }, 
+ 
+  ];
 
-  var idKeyMap = {
-      btc: 'id44btc',
-      bch: 'id44bch',
-  };
+  _.each(testSet, function(x) {
 
-  _.each(['bch', 'btc'], function(coin) {
+    let coin = x.coin;
+    let idKey = x.key;
+    let addressStr = x.addr;
+    let flags = x.flags;
   
-    describe('#createTx ' + coin, function() {
-      var addressStr, idKey;
-      before(function() {
-        addressStr = addrMap[coin];
-        idKey = idKeyMap[coin];
-      });
-
-
-
+    describe('#createTx ' + coin + ' flags' + JSON.stringify(flags), function() {
       describe('Tx proposal creation & publishing ' + coin, function() {
         var server, wallet;
         beforeEach(function(done) {
@@ -2560,6 +2569,7 @@ console.log('[server.js.425:err:]',err); //TODO
               customData: 'some custom data',
               feePerKb: 123e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(err);
               should.exist(tx);
@@ -2595,6 +2605,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 outputs: [],
                 feePerKb: 123e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.exist(err);
                 should.not.exist(tx);
@@ -2603,6 +2614,7 @@ console.log('[server.js.425:err:]',err); //TODO
               });
             });
           });
+    
           it('should fail to create tx for invalid address', function(done) {
             helpers.stubUtxos(server, wallet, 1, function() {
               var txOpts = {
@@ -2612,6 +2624,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.exist(err);
                 should.not.exist(tx);
@@ -2629,6 +2642,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(tx);
                 should.exist(err);
@@ -2646,6 +2660,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(tx);
               should.exist(err);
@@ -2663,6 +2678,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 feeLevel: 'normal',
                 feePerKb: 123e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.exist(err);
                 should.not.exist(txp);
@@ -2684,6 +2700,7 @@ console.log('[server.js.425:err:]',err); //TODO
                   feePerKb: 100e2,
                   inputs: inputs,
                 };
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, tx) {
                   should.not.exist(err);
                   should.exist(tx);
@@ -2706,6 +2723,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 feePerKb: 100e2,
                 changeAddress: utxos[0].address,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
@@ -2727,8 +2745,9 @@ console.log('[server.js.425:err:]',err); //TODO
                   amount: 0.8e8,
                 }],
                 feePerKb: 100e2,
-                changeAddress: addr.toString(),
+                changeAddress: addr.toString(true),
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.exist(err);
                 err.code.should.equal('INVALID_CHANGE_ADDRESS');
@@ -2747,6 +2766,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 inputs: utxos,
                 fee: 1000e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
@@ -2773,6 +2793,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
@@ -2791,10 +2812,12 @@ console.log('[server.js.425:err:]',err); //TODO
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
                 tx.id.should.equal('123');
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, tx) {
                   should.not.exist(err);
                   should.exist(tx);
@@ -2819,6 +2842,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 }],
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.not.exist(err);
                 should.exist(tx);
@@ -2827,6 +2851,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 server.publishTx(publishOpts, function(err, tx) {
                   should.not.exist(err);
                   should.exist(tx);
+              txOpts = Object.assign(txOpts, flags);
                   server.createTx(txOpts, function(err, tx) {
                     should.not.exist(err);
                     should.exist(tx);
@@ -2856,6 +2881,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 message: 'some message',
                 customData: 'some custom data',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -2882,6 +2908,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 feePerKb: 100e2,
                 dryRun: true,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -2908,6 +2935,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 feePerKb: 100e2,
                 message: 'some message',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -2958,6 +2986,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 feePerKb: 100e2,
                 message: 'some message',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -2982,6 +3011,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 feePerKb: 100e2,
                 message: 'some message',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3018,10 +3048,12 @@ console.log('[server.js.425:err:]',err); //TODO
                 });
               },
               function(next) {
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp, next) {
                 txp1 = txp;
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp, next) {
@@ -3048,6 +3080,7 @@ console.log('[server.js.425:err:]',err); //TODO
               },
               function(next) {
                 // A new tx proposal should use the next available UTXO
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp3, next) {
@@ -3086,10 +3119,12 @@ console.log('[server.js.425:err:]',err); //TODO
                 });
               },
               function(next) {
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp, next) {
                 txp1 = txp;
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, next);
               },
               function(txp, next) {
@@ -3154,6 +3189,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 // ToDo
                 feeLevel: level,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3172,6 +3208,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 }],
                 feeLevel: 'madeUpLevel',
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.exist(err);
                 should.not.exist(txp);
@@ -3194,6 +3231,7 @@ console.log('[server.js.425:err:]',err); //TODO
                   amount: 1e8,
                 }],
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3213,9 +3251,11 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx1) {
               should.not.exist(err);
               should.exist(tx1);
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx2) {
                 should.not.exist(err);
                 should.exist(tx2);
@@ -3235,6 +3275,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, txp) {
               should.not.exist(err);
               should.exist(txp);
@@ -3256,6 +3297,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.toString().should.equal('dummy error');
@@ -3277,6 +3319,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.message.should.equal('dummy exception');
@@ -3296,6 +3339,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('TX_MAX_SIZE_EXCEEDED');
@@ -3313,12 +3357,14 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               server.getBalance({}, function(err, balance) {
                 should.not.exist(err);
                 balance.totalAmount.should.equal(2e8);
                 balance.lockedAmount.should.equal(2e8);
                 txOpts.outputs[0].amount = 0.8e8;
+                txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, tx) {
                   should.exist(err);
                   err.code.should.equal('LOCKED_FUNDS');
@@ -3338,6 +3384,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('DUST_AMOUNT');
@@ -3358,6 +3405,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(err);
               should.exist(tx);
@@ -3377,9 +3425,11 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               txOpts.outputs[0].amount = 0.8e8;
+              txOpts = Object.assign(txOpts, flags);
               helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
                 should.exist(tx);
                 server.getPendingTxs({}, function(err, txs) {
@@ -3405,9 +3455,11 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               txOpts.outputs[0].amount = 1.8e8;
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 err.code.should.equal('LOCKED_FUNDS');
                 should.not.exist(tx);
@@ -3452,6 +3504,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 message: 'some message',
                 feePerKb: 100e2,
               };
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3487,6 +3540,7 @@ console.log('[server.js.425:err:]',err); //TODO
               feePerKb: 10000,
               sendMax: true,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(err);
               should.exist(tx);
@@ -3513,6 +3567,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }),
               feePerKb: 123e2,
             };
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, txp) {
               should.not.exist(err);
               should.exist(txp);
@@ -3522,6 +3577,7 @@ console.log('[server.js.425:err:]',err); //TODO
 
               outputs.should.not.deep.equal(_.map(txOpts.outputs, 'amount'));
               txOpts.noShuffleOutputs = true;
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, txp) {
                 should.not.exist(err);
                 should.exist(txp);
@@ -3571,6 +3627,7 @@ console.log('[server.js.425:err:]',err); //TODO
 
           function(next) {
             async.each(_.range(3), function(i, next) {
+                txOpts = Object.assign(txOpts, flags);
                 helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
                   server.rejectTx({
                     txProposalId: tx.id,
@@ -3582,6 +3639,7 @@ console.log('[server.js.425:err:]',err); //TODO
           },
           function(next) {
             // Allow a 4th tx
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               server.rejectTx({
                 txProposalId: tx.id,
@@ -3591,6 +3649,7 @@ console.log('[server.js.425:err:]',err); //TODO
           },
           function(next) {
             // Do not allow before backoff time
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('TX_CANNOT_CREATE');
@@ -3599,6 +3658,7 @@ console.log('[server.js.425:err:]',err); //TODO
           },
           function(next) {
             clock.tick((Defaults.BACKOFF_TIME + 1) * 1000);
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               server.rejectTx({
                 txProposalId: tx.id,
@@ -3609,6 +3669,7 @@ console.log('[server.js.425:err:]',err); //TODO
           function(next) {
             // Do not allow a 5th tx before backoff time
             clock.tick((Defaults.BACKOFF_TIME - 1) * 1000);
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('TX_CANNOT_CREATE');
@@ -3617,6 +3678,7 @@ console.log('[server.js.425:err:]',err); //TODO
           },
           function(next) {
             clock.tick(2000);
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               server.rejectTx({
                 txProposalId: tx.id,
@@ -3655,11 +3717,13 @@ console.log('[server.js.425:err:]',err); //TODO
             feePerKb: 100e2,
             excludeUnconfirmedUtxos: true,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, tx) {
             should.exist(err);
             err.code.should.equal('INSUFFICIENT_FUNDS');
             err.message.should.equal('Insufficient funds');
             txOpts.outputs[0].amount = 2.5e8;
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.exist(err);
               err.code.should.equal('INSUFFICIENT_FUNDS_FOR_FEE');
@@ -3679,6 +3743,7 @@ console.log('[server.js.425:err:]',err); //TODO
             feePerKb: 100e2,
             excludeUnconfirmedUtxos: true,
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
             should.exist(tx);
             tx.inputs.length.should.equal(2);
@@ -3687,6 +3752,7 @@ console.log('[server.js.425:err:]',err); //TODO
               balance.lockedConfirmedAmount.should.equal(helpers.toSatoshi(2.5));
               balance.availableConfirmedAmount.should.equal(0);
               txOpts.outputs[0].amount = 0.01e8;
+              txOpts = Object.assign(txOpts, flags);
               server.createTx(txOpts, function(err, tx) {
                 should.exist(err);
                 err.code.should.equal('LOCKED_FUNDS');
@@ -3706,11 +3772,13 @@ console.log('[server.js.425:err:]',err); //TODO
             feePerKb: 100e2,
             utxosToExclude: [utxos[2].txid + ':' + utxos[2].vout],
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, tx) {
             should.exist(err);
             err.code.should.equal('INSUFFICIENT_FUNDS');
             err.message.should.equal('Insufficient funds');
             txOpts.utxosToExclude = [utxos[0].txid + ':' + utxos[0].vout];
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, tx) {
               should.not.exist(err);
               should.exist(tx);
@@ -3728,6 +3796,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3748,6 +3817,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 100e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3770,6 +3840,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3789,6 +3860,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3809,6 +3881,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3831,6 +3904,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 1200e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3852,6 +3926,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 20e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3871,6 +3946,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3894,6 +3970,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 120e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3914,11 +3991,13 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 80e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
             txp.inputs.length.should.equal(3);
             txOpts.feePerKb = 160e2;
+              txOpts = Object.assign(txOpts, flags);
             server.createTx(txOpts, function(err, txp) {
               should.exist(err);
               should.not.exist(txp);
@@ -3936,6 +4015,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.exist(err);
             should.not.exist(txp);
@@ -3953,6 +4033,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.exist(err);
             should.not.exist(txp);
@@ -3972,6 +4053,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -3991,6 +4073,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 100e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -4011,6 +4094,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 90e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -4030,6 +4114,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 10e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -4047,6 +4132,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 100e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             txp.inputs.length.should.equal(1);
@@ -4068,6 +4154,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 80e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.exist(err);
             err.code.should.equal('INSUFFICIENT_FUNDS_FOR_FEE');
@@ -4084,6 +4171,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 100e2,
           };
+              txOpts = Object.assign(txOpts, flags);
           server.createTx(txOpts, function(err, txp) {
             should.not.exist(err);
             should.exist(txp);
@@ -4100,6 +4188,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 100e2,
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             should.exist(txp);
             var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);
@@ -4117,6 +4206,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 should.not.exist(err);
                 should.exist(txp.txid);
                 txp.status.should.equal('broadcasted');
+              txOpts = Object.assign(txOpts, flags);
                 server.createTx(txOpts, function(err, txp) {
                   should.exist(err);
                   err.code.should.equal('INSUFFICIENT_FUNDS');
@@ -4131,53 +4221,172 @@ console.log('[server.js.425:err:]',err); //TODO
     });
   });
 
-  it('should create a BCH tx proposal with cashaddr outputs (w/o prefix) and return Copay addr', function(done) {
+  describe("cashAddr backwards compat", (x) => {
+    /// LEGACY MODE
+    it('should create a BCH tx proposal with cashaddr outputs (w/o prefix) and return Copay addr', function(done) {
 
-    let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
-    let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
-    let amount =  0.8 * 1e8;
-    helpers.createAndJoinWallet(1, 1, { 
-      coin: 'bch',
-    },  function(s, w) {
-      helpers.stubUtxos(s, w, [1, 2], function() {
-        var txOpts = {
-          outputs: [{
-            toAddress: cashAddr,
-            amount: amount,
-          }],
-          message: 'some message',
-          customData: 'some custom data',
-          feePerKb: 123e2,
-        };
-        s.createTx(txOpts, function(err, tx) {
-          should.not.exist(err);
-          should.exist(tx);
-          tx.walletM.should.equal(1);
-          tx.walletN.should.equal(1);
-          tx.requiredRejections.should.equal(1);
-          tx.requiredSignatures.should.equal(1);
-          tx.isAccepted().should.equal.false;
-          tx.isRejected().should.equal.false;
-          tx.isPending().should.equal.true;
-          tx.isTemporary().should.equal.true;
-          tx.outputs.should.deep.equal([{
-            toAddress: cashAddr,
-            amount: amount,
-          }]);
-          tx.amount.should.equal(helpers.toSatoshi(0.8));
-          tx.feePerKb.should.equal(123e2);
-          should.not.exist(tx.feeLevel);
-          var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
-          s.publishTx(publishOpts, function(err) {
-            s.getPendingTxs({}, function(err, txs) {
-              should.not.exist(err);
-              txs.length.should.equal(1);
-              txs[0].outputs.should.deep.equal([{
-                toAddress: copayAddr,
-                amount: amount,
-              }]);
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: cashAddr,
+              amount: amount,
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+            noCashAddr:true,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            should.not.exist(err);
+            should.exist(tx);
+            tx.walletM.should.equal(1);
+            tx.walletN.should.equal(1);
+            tx.requiredRejections.should.equal(1);
+            tx.requiredSignatures.should.equal(1);
+            tx.isAccepted().should.equal.false;
+            tx.isRejected().should.equal.false;
+            tx.isPending().should.equal.true;
+            tx.isTemporary().should.equal.true;
+            tx.outputs.should.deep.equal([{
+              toAddress: cashAddr,
+              amount: amount,
+            }]);
+            tx.amount.should.equal(helpers.toSatoshi(0.8));
+            tx.feePerKb.should.equal(123e2);
+            should.not.exist(tx.feeLevel);
+            var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
+            s.publishTx(publishOpts, function(err) {
+              s.getPendingTxs({noCashAddr: true}, function(err, txs) {
+                should.not.exist(err);
+                txs.length.should.equal(1);
+                txs[0].outputs.should.deep.equal([{
+                  toAddress: copayAddr,
+                  amount: amount,
+                }]);
 
-              done();
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('should create a BCH tx proposal with cashaddr outputs (w/ prefix) and return Copay addr', function(done) {
+
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: 'bitcoincash:'+cashAddr,
+              amount: amount,
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+            noCashAddr: true,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            should.not.exist(err);
+            should.exist(tx);
+            tx.walletM.should.equal(1);
+            tx.walletN.should.equal(1);
+            tx.requiredRejections.should.equal(1);
+            tx.requiredSignatures.should.equal(1);
+            tx.isAccepted().should.equal.false;
+            tx.isRejected().should.equal.false;
+            tx.isPending().should.equal.true;
+            tx.isTemporary().should.equal.true;
+            tx.outputs.should.deep.equal([{
+              toAddress: 'bitcoincash:'+cashAddr,
+              amount: amount,
+            }]);
+            tx.amount.should.equal(helpers.toSatoshi(0.8));
+            tx.feePerKb.should.equal(123e2);
+            should.not.exist(tx.feeLevel);
+
+            var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
+            s.publishTx(publishOpts, function(err) {
+              s.getPendingTxs({noCashAddr: true}, function(err, txs) {
+            
+                should.not.exist(err);
+                txs.length.should.equal(1);
+                txs[0].outputs.should.deep.equal([{
+                  toAddress: copayAddr,
+                  amount: amount,
+                }]);
+
+                done();
+              });
+            });
+          });
+        });
+      });
+    });
+
+    it('should create a BCH tx proposal with cashaddr and keep message', function(done) {
+
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: cashAddr,
+              amount: amount,
+              message: 'xxx',
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+            noCashAddr: true,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            should.not.exist(err);
+            should.exist(tx);
+            tx.walletM.should.equal(1);
+            tx.walletN.should.equal(1);
+            tx.requiredRejections.should.equal(1);
+            tx.requiredSignatures.should.equal(1);
+            tx.isAccepted().should.equal.false;
+            tx.isRejected().should.equal.false;
+            tx.isPending().should.equal.true;
+            tx.isTemporary().should.equal.true;
+            tx.outputs.should.deep.equal([{
+              toAddress: cashAddr,
+              amount: amount,
+              message: 'xxx',
+            }]);
+            tx.amount.should.equal(helpers.toSatoshi(0.8));
+            tx.feePerKb.should.equal(123e2);
+            should.not.exist(tx.feeLevel);
+            var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
+            s.publishTx(publishOpts, function(err) {
+              s.getPendingTxs({noCashAddr: true}, function(err, txs) {
+                should.not.exist(err);
+                txs.length.should.equal(1);
+                txs[0].outputs.should.deep.equal([{
+                  toAddress: copayAddr,
+                  message: 'xxx',
+                  amount: amount,
+                }]);
+
+                done();
+              });
             });
           });
         });
@@ -4185,110 +4394,107 @@ console.log('[server.js.425:err:]',err); //TODO
     });
   });
 
-  it('should create a BCH tx proposal with cashaddr outputs (w/ prefix) and return Copay addr', function(done) {
+  describe("cashAddr edge cases (v3 api)", (x) => {
+    it('should fail to create BCH tx proposal with cashaddr w/prefix', function(done) {
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: 'bitcoincash:'+ cashAddr,
+              amount: amount,
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            err.message.should.contain('cashaddr wo prefix');
+            done();
+          });
+        });
+      });
+    });
+    it('should fail to create BCH tx proposal with  legacy addr  ', function(done) {
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.stubUtxos(s, w, [1, 2], function() {
+          var txOpts = {
+            outputs: [{
+              toAddress: copayAddr,
+              amount: amount,
+            }],
+            message: 'some message',
+            customData: 'some custom data',
+            feePerKb: 123e2,
+          };
+          s.createTx(txOpts, function(err, tx) {
+            err.message.should.contain('cashaddr wo prefix');
+            done();
+          });
+        });
+      });
+    });
 
-    let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
-    let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
-    let amount =  0.8 * 1e8;
-    helpers.createAndJoinWallet(1, 1, { 
-      coin: 'bch',
-    },  function(s, w) {
-      helpers.stubUtxos(s, w, [1, 2], function() {
-        var txOpts = {
-          outputs: [{
-            toAddress: 'bitcoincash:'+cashAddr,
-            amount: amount,
-          }],
-          message: 'some message',
-          customData: 'some custom data',
-          feePerKb: 123e2,
-        };
-        s.createTx(txOpts, function(err, tx) {
-          should.not.exist(err);
-          should.exist(tx);
-          tx.walletM.should.equal(1);
-          tx.walletN.should.equal(1);
-          tx.requiredRejections.should.equal(1);
-          tx.requiredSignatures.should.equal(1);
-          tx.isAccepted().should.equal.false;
-          tx.isRejected().should.equal.false;
-          tx.isPending().should.equal.true;
-          tx.isTemporary().should.equal.true;
-          tx.outputs.should.deep.equal([{
-            toAddress: 'bitcoincash:'+cashAddr,
-            amount: amount,
-          }]);
-          tx.amount.should.equal(helpers.toSatoshi(0.8));
-          tx.feePerKb.should.equal(123e2);
-          should.not.exist(tx.feeLevel);
-
-          var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
-          s.publishTx(publishOpts, function(err) {
-            s.getPendingTxs({}, function(err, txs) {
-              should.not.exist(err);
-              txs.length.should.equal(1);
-              txs[0].outputs.should.deep.equal([{
-                toAddress: copayAddr,
+    it('should allow cashaddr on change address', function(done) {
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.createAddresses(s, w, 1, 1, function(mainAddresses, changeAddress) {
+          helpers.stubUtxos(s, w, [1, 2], function() {
+            var txOpts = {
+              outputs: [{
+                toAddress: cashAddr,
                 amount: amount,
-              }]);
-
+              }],
+              message: 'some message',
+              customData: 'some custom data',
+              feePerKb: 123e2,
+              changeAddress: changeAddress[0].address,
+            };
+            s.createTx(txOpts, function(err, tx) {
+              should.not.exist(err);
+              tx.changeAddress.address.should.equal(changeAddress[0].address);
+              tx.changeAddress.address.should.equal('qz0d6gueltx0feta7z9777yk97sz9p6peu98mg5vac');
               done();
             });
           });
         });
       });
     });
-  });
 
-  it('should create a BCH tx proposal with cashaddr and keep message', function(done) {
-
-    let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
-    let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
-    let amount =  0.8 * 1e8;
-    helpers.createAndJoinWallet(1, 1, { 
-      coin: 'bch',
-    },  function(s, w) {
-      helpers.stubUtxos(s, w, [1, 2], function() {
-        var txOpts = {
-          outputs: [{
-            toAddress: cashAddr,
-            amount: amount,
-            message: 'xxx',
-          }],
-          message: 'some message',
-          customData: 'some custom data',
-          feePerKb: 123e2,
-        };
-        s.createTx(txOpts, function(err, tx) {
-          should.not.exist(err);
-          should.exist(tx);
-          tx.walletM.should.equal(1);
-          tx.walletN.should.equal(1);
-          tx.requiredRejections.should.equal(1);
-          tx.requiredSignatures.should.equal(1);
-          tx.isAccepted().should.equal.false;
-          tx.isRejected().should.equal.false;
-          tx.isPending().should.equal.true;
-          tx.isTemporary().should.equal.true;
-          tx.outputs.should.deep.equal([{
-            toAddress: cashAddr,
-            amount: amount,
-            message: 'xxx',
-          }]);
-          tx.amount.should.equal(helpers.toSatoshi(0.8));
-          tx.feePerKb.should.equal(123e2);
-          should.not.exist(tx.feeLevel);
-          var publishOpts = helpers.getProposalSignatureOpts(tx, TestData.copayers[0].privKey_1H_0);
-          s.publishTx(publishOpts, function(err) {
-            s.getPendingTxs({}, function(err, txs) {
-              should.not.exist(err);
-              txs.length.should.equal(1);
-              txs[0].outputs.should.deep.equal([{
-                toAddress: copayAddr,
-                message: 'xxx',
+    it('should not allow cashaddr w prefix on change address', function(done) {
+      let copayAddr = 'CPrtPWbp8cCftTQu5fzuLG5zPJNDHMMf8X';
+      let cashAddr = BCHAddressTranslator.translate(copayAddr,'cashaddr');
+      let amount =  0.8 * 1e8;
+      helpers.createAndJoinWallet(1, 1, { 
+        coin: 'bch',
+      },  function(s, w) {
+        helpers.createAddresses(s, w, 1, 1, function(mainAddresses, changeAddress) {
+          helpers.stubUtxos(s, w, [1, 2], function() {
+            var txOpts = {
+              outputs: [{
+                toAddress: cashAddr,
                 amount: amount,
-              }]);
-
+              }],
+              message: 'some message',
+              customData: 'some custom data',
+              feePerKb: 123e2,
+              changeAddress: 'bitcoincash:' + changeAddress[0].address,
+            };
+            s.createTx(txOpts, function(err, tx) {
+              err.message.should.contain('wo prefix');
               done();
             });
           });
@@ -5041,6 +5247,7 @@ console.log('[server.js.425:err:]',err); //TODO
             }],
             feePerKb: 100e2,
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
             should.exist(tx);
             txid = tx.id;
@@ -5136,6 +5343,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               tx.addressType.should.equal('P2PKH');
@@ -5190,6 +5398,7 @@ console.log('[server.js.425:err:]',err); //TODO
               }],
               feePerKb: 100e2,
             };
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
               should.exist(tx);
               txid = tx.id;
@@ -5402,6 +5611,7 @@ console.log('[server.js.425:err:]',err); //TODO
             message: 'some message',
             feePerKb: 100e2,
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             should.exist(txp);
             var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);
@@ -5492,6 +5702,7 @@ console.log('[server.js.425:err:]',err); //TODO
         }],
         feePerKb: 100e2,
       };
+      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         server.getPendingTxs({}, function(err, txs) {
           should.not.exist(err);
@@ -5518,6 +5729,7 @@ console.log('[server.js.425:err:]',err); //TODO
         }],
         feePerKb: 100e2,
       };
+      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         should.exist(txp);
         server.broadcastTx({
@@ -5613,6 +5825,7 @@ console.log('[server.js.425:err:]',err); //TODO
         feePerKb: 100e2,
         message: 'some message',
       };
+      txOpts = Object.assign(txOpts, flags);
       helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
         should.exist(txp);
         helpers.getAuthServer(wallet.copayers[1].id, function(server2, wallet) {
@@ -5639,6 +5852,7 @@ console.log('[server.js.425:err:]',err); //TODO
             feePerKb: 100e2,
             message: 'some message',
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             txpId = txp.id;
             should.exist(txp);
@@ -5732,6 +5946,7 @@ console.log('[server.js.425:err:]',err); //TODO
             feePerKb: 100e2,
             message: 'some message',
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             txpId = txp.id;
             should.exist(txp);
@@ -5820,6 +6035,7 @@ console.log('[server.js.425:err:]',err); //TODO
             feePerKb: 100e2,
             message: 'some message',
           };
+          txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
             should.exist(txp);
             txpid = txp.id;
@@ -5886,6 +6102,7 @@ console.log('[server.js.425:err:]',err); //TODO
           };
           async.eachSeries(_.range(10), function(i, next) {
             clock.tick(10 * 1000);
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
 
               next();
@@ -5974,6 +6191,7 @@ console.log('[server.js.425:err:]',err); //TODO
           };
           async.eachSeries(_.range(3), function(i, next) {
             clock.tick(25 * 1000);
+            txOpts = Object.assign(txOpts, flags);
             helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
               next();
             });
@@ -6243,6 +6461,7 @@ console.log('[server.js.425:err:]',err); //TODO
             feePerKb: 100e2,
             message: 'some message',
           };
+            txOpts = Object.assign(txOpts, flags);
           helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function() {
             server.getPendingTxs({}, function(err, txs) {
               txp = txs[0];
@@ -6572,6 +6791,7 @@ console.log('[server.js.425:err:]',err); //TODO
             "test": true
           },
         };
+        txOpts = Object.assign(txOpts, flags);
         helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(tx) {
           should.exist(tx);
 
@@ -8117,6 +8337,7 @@ console.log('[server.js.7446:err:]',err); //TODO
           feePerKb: 100e2,
           message: 'some message',
         };
+        txOpts = Object.assign(txOpts, flags);
         helpers.createAndPublishTx(server, txOpts, TestData.copayers[0].privKey_1H_0, function(txp) {
           should.exist(txp);
           var signatures = helpers.clientSign(txp, TestData.copayers[0].xPrivKey_44H_0H_0H);

--- a/test/integration/server.js
+++ b/test/integration/server.js
@@ -1331,7 +1331,7 @@ console.log('[server.js.425:err:]',err); //TODO
           should.exist(address);
           address.walletId.should.equal(wallet.id);
           address.network.should.equal('livenet');
-          address.address.should.equal('HBf8isgS8EXG1r3X6GP89FmooUmiJ42wHS');
+          address.address.should.equal('pqu9c0xe7g0ngz9hzpky64nva9790m64esxxjmcv2k');
           address.isChange.should.be.false;
           address.path.should.equal('m/0/0');
           address.type.should.equal('P2SH');
@@ -1400,7 +1400,7 @@ console.log('[server.js.425:err:]',err); //TODO
           should.exist(address);
           address.walletId.should.equal(wallet.id);
           address.network.should.equal('livenet');
-          address.address.should.equal('HBf8isgS8EXG1r3X6GP89FmooUmiJ42wHS');
+          address.address.should.equal('pqu9c0xe7g0ngz9hzpky64nva9790m64esxxjmcv2k');
           address.isChange.should.be.false;
           address.path.should.equal('m/0/0');
           address.type.should.equal('P2SH');
@@ -1471,7 +1471,7 @@ console.log('[server.js.425:err:]',err); //TODO
           should.exist(address);
           address.walletId.should.equal(wallet.id);
           address.network.should.equal('testnet');
-          address.address.should.equal('mrM5kMkqZccK5MxZYSsM3SjqdMaNKLJgrJ');
+          address.address.should.equal('qpmvku3x8j9pz7mee89c590xsl3k5l02mqeyfhf3ce');
           address.isChange.should.be.false;
           address.path.should.equal('m/0/0');
           address.type.should.equal('P2PKH');
@@ -2104,7 +2104,7 @@ console.log('[server.js.425:err:]',err); //TODO
         server.getBalance({
           coin: 'bch'
         }, function(err, balance) {
-          err.message.should.contain('no longer supported');
+          err.message.should.contain('not longer supported');
           done();
         });
       });
@@ -2711,11 +2711,7 @@ console.log('[server.js.425:err:]',err); //TODO
                 should.exist(tx);
                 var t = tx.getBitcoreTx();
 
-                if (coin == 'bch') { 
-                  t.getChangeOutput().script.toAddress().toLegacyAddress().should.equal(txOpts.changeAddress);
-                } else {
-                  t.getChangeOutput().script.toAddress().toString().should.equal(txOpts.changeAddress);
-                }
+                t.getChangeOutput().script.toAddress().toString(true).should.equal(txOpts.changeAddress);
                 done();
               });
             });
@@ -8272,7 +8268,7 @@ console.log('[server.js.7446:err:]',err); //TODO
           address.walletId.should.equal(wallet.bch.id);
           address.coin.should.equal('bch');
           address.network.should.equal('livenet');
-          address.address.should.equal('CbWsiNjh18ynQYc5jfYhhespEGrAaW8YUq');
+          address.address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
           server.btc.getMainAddresses({}, function(err, addresses) {
             should.not.exist(err);
             addresses.length.should.equal(1);
@@ -8284,7 +8280,7 @@ console.log('[server.js.7446:err:]',err); //TODO
               addresses.length.should.equal(1);
               addresses[0].coin.should.equal('bch');
               addresses[0].walletId.should.equal(wallet.bch.id);
-              addresses[0].address.should.equal('CbWsiNjh18ynQYc5jfYhhespEGrAaW8YUq');
+              addresses[0].address.should.equal('qrg04mz8h67j9dck3f3f3sa560taep87yqnwra9ak6');
               done();
             });
           });


### PR DESCRIPTION
- update BWS to use cashaddr internally

- support old BWC clients, (address and txp creation with legacy `copay` address for ok verification), by adding params to the now deprecated API endpoints.

- add entry points to new address & txp creation in `expressapp`

- fix error handling sockets notification
https://github.com/bitpay/bitcore-wallet-service/pull/826/files#diff-d0e088b0e4849ed8aec473d9e9aaf136R383

- fix setAddress in getBalance (opts.coin no always set)
https://github.com/bitpay/bitcore-wallet-service/pull/826/files#diff-c945a46d13b34fcaff544d966cffcabaR1571